### PR TITLE
feat: add Vue CLI support to Rsbuild migration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Use when upgrading a Rsbuild 1.x project to v2, including dependency and configu
 npx skills add rstackjs/agent-skills --skill migrate-to-rsbuild
 ```
 
-Migrate webpack, Vite, or CRA/CRACO projects to Rsbuild. Use when a user asks to migrate an existing project to Rsbuild, follow the migration guide, update scripts/configs/plugins, and verify dev/build behavior.
+Migrate webpack, Vite, create-react-app (CRA/CRACO), or Vue CLI projects to Rsbuild.
 
 ## Rspress Skills
 

--- a/skills/migrate-to-rsbuild/SKILL.md
+++ b/skills/migrate-to-rsbuild/SKILL.md
@@ -1,19 +1,20 @@
 ---
 name: migrate-to-rsbuild
-description: Migrate webpack, Vite, or CRA/CRACO projects to Rsbuild. Use when a user asks to migrate an existing project to Rsbuild, follow the migration guide, update scripts/configs/plugins, and verify dev/build behavior.
+description: Migrate webpack, Vite, create-react-app (CRA/CRACO), or Vue CLI projects to Rsbuild.
 ---
 
 # Migrate to Rsbuild
 
 ## Goal
 
-Migrate webpack, Vite, or CRA/CRACO projects to Rsbuild with minimal behavior changes and clear verification.
+Migrate webpack, Vite, create-react-app (CRA/CRACO), or Vue CLI projects to Rsbuild with minimal behavior changes and clear verification.
 
 ## Supported source frameworks
 
 - webpack
 - Vite
 - CRA / CRACO
+- Vue CLI
 
 ## Migration principles (must follow)
 
@@ -29,11 +30,13 @@ Migrate webpack, Vite, or CRA/CRACO projects to Rsbuild with minimal behavior ch
      - webpack: `webpack.config.*`
      - Vite: `vite.config.*`
      - CRA/CRACO: `react-scripts`, `@craco/craco`, `craco.config.*`
+     - Vue CLI: `@vue/cli-service`, `vue.config.*`
 
 2. **Apply framework-specific deltas**
    - webpack: `references/webpack.md`
    - Vite: `references/vite.md`
    - CRA/CRACO: `references/cra.md`
+   - Vue CLI: `references/vue-cli.md`
 
 3. **Validate behavior**
    - Run dev server to verify the project starts without errors.

--- a/skills/migrate-to-rsbuild/references/vue-cli.md
+++ b/skills/migrate-to-rsbuild/references/vue-cli.md
@@ -1,0 +1,22 @@
+# Vue CLI -> Rsbuild Migration Checklist
+
+Use this reference when the source project is Vue CLI (`@vue/cli-service`).
+
+## Checklist
+
+Copy this checklist and check off items as you complete them:
+
+- [ ] Step 0: Read official guide (https://rsbuild.rs/guide/migration/vue-cli) ⛔ BLOCKING
+- [ ] Step 1: Inventory Vue CLI-specific behavior
+  - [ ] Record `vue.config.*` customizations (`configureWebpack`, `chainWebpack`, `devServer`, `css.loaderOptions`, `publicPath`)
+  - [ ] Record Vue CLI plugins (`@vue/cli-plugin-*`) and any plugin-dependent behavior
+- [ ] Step 2: Execute migration by official guide
+  - [ ] Apply guide steps with minimal scope
+  - [ ] Map Vue CLI config/plugin behavior
+- [ ] Step 3: Verify behavior
+  - [ ] Dev pass without errors
+  - [ ] Build pass without errors
+  - [ ] Run type check if required
+- [ ] Step 4: Cleanup and summarize
+  - [ ] Remove Vue CLI-only deps/config after verification
+  - [ ] Summarize remaining manual follow-ups


### PR DESCRIPTION
Add Vue CLI to the list of supported frameworks for Rsbuild migration. Include a new reference file with detailed migration checklist for Vue CLI projects and update related documentation.