### PR TITLE
feat: add rsbuild-docs skill

### DIFF
--- a/rsbuild-docs-workspace/evals/evals.json
+++ b/rsbuild-docs-workspace/evals/evals.json
@@ -1,0 +1,26 @@
+{
+  "skill_name": "rsbuild-docs",
+  "evals": [
+    {
+      "id": 0,
+      "prompt": "我在用 Rsbuild，想把 /api 开头的请求代理到 http://localhost:3000，怎么配置？",
+      "expected_output": "Should explain dev.proxy or server.proxy config with a concrete code example",
+      "files": [],
+      "assertions": []
+    },
+    {
+      "id": 1,
+      "prompt": "Rsbuild 里怎么修改 CSS Modules 生成的类名格式？比如我想用 [name]__[local] 这种格式",
+      "expected_output": "Should explain output.cssModules.localIdentName config with code example",
+      "files": [],
+      "assertions": []
+    },
+    {
+      "id": 2,
+      "prompt": "我有一个 Create React App 项目想迁移到 Rsbuild，大概要怎么做？有什么需要注意的？",
+      "expected_output": "Should provide step-by-step CRA migration guide based on the official migration doc",
+      "files": [],
+      "assertions": []
+    }
+  ]
+}

--- a/rsbuild-docs-workspace/iteration-1/benchmark.json
+++ b/rsbuild-docs-workspace/iteration-1/benchmark.json
@@ -1,0 +1,171 @@
+{
+  "metadata": {
+    "skill_name": "rsbuild-docs",
+    "skill_path": "/Users/bytedance/Documents/codes/agent-skills/skills/rsbuild-docs/SKILL.md",
+    "executor_model": "claude-opus-4-6",
+    "timestamp": "2026-03-10T11:51:37Z",
+    "evals_run": ["dev-proxy-config", "css-modules-classname"],
+    "runs_per_configuration": 1,
+    "note": "CRA migration eval was skipped due to rate limit"
+  },
+  "runs": [
+    {
+      "eval_name": "dev-proxy-config",
+      "eval_id": 0,
+      "prompt": "我在用 Rsbuild，想把 /api 开头的请求代理到 http://localhost:3000，怎么配置？",
+      "configurations": [
+        {
+          "name": "with_skill",
+          "pass_rate": 1.0,
+          "passed": 4,
+          "total": 4,
+          "time_seconds": 42.5,
+          "tokens": 12091,
+          "expectations": [
+            {
+              "text": "Has concrete rsbuild.config code snippet with proxy",
+              "passed": true,
+              "evidence": "Multiple server.proxy examples"
+            },
+            {
+              "text": "Mentions correct config path (server.proxy)",
+              "passed": true,
+              "evidence": "Uses server.proxy throughout"
+            },
+            {
+              "text": "Correctly maps /api to http://localhost:3000",
+              "passed": true,
+              "evidence": "'/api': 'http://localhost:3000'"
+            },
+            {
+              "text": "Sourced from fetched docs",
+              "passed": true,
+              "evidence": "References rsbuild.rs/config/server/proxy"
+            }
+          ]
+        },
+        {
+          "name": "without_skill",
+          "pass_rate": 0.75,
+          "passed": 3,
+          "total": 4,
+          "time_seconds": 19.8,
+          "tokens": 9076,
+          "expectations": [
+            {
+              "text": "Has concrete rsbuild.config code snippet with proxy",
+              "passed": true,
+              "evidence": "Multiple server.proxy examples"
+            },
+            {
+              "text": "Mentions correct config path (server.proxy)",
+              "passed": true,
+              "evidence": "Uses server.proxy throughout"
+            },
+            {
+              "text": "Correctly maps /api to http://localhost:3000",
+              "passed": true,
+              "evidence": "'/api': 'http://localhost:3000'"
+            },
+            {
+              "text": "Sourced from fetched docs",
+              "passed": false,
+              "evidence": "No docs fetched, model knowledge only"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "eval_name": "css-modules-classname",
+      "eval_id": 1,
+      "prompt": "Rsbuild 里怎么修改 CSS Modules 生成的类名格式？比如我想用 [name]__[local] 这种格式",
+      "configurations": [
+        {
+          "name": "with_skill",
+          "pass_rate": 1.0,
+          "passed": 4,
+          "total": 4,
+          "time_seconds": 44.3,
+          "tokens": 12796,
+          "expectations": [
+            {
+              "text": "Has concrete cssModules config code snippet",
+              "passed": true,
+              "evidence": "Shows output.cssModules block"
+            },
+            {
+              "text": "Mentions correct config path (output.cssModules.localIdentName)",
+              "passed": true,
+              "evidence": "Correctly identified"
+            },
+            {
+              "text": "Shows [name]__[local] pattern",
+              "passed": true,
+              "evidence": "localIdentName: '[name]__[local]'"
+            },
+            {
+              "text": "Sourced from fetched docs",
+              "passed": true,
+              "evidence": "References rsbuild.rs/config/output/css-modules"
+            }
+          ]
+        },
+        {
+          "name": "without_skill",
+          "pass_rate": 0.75,
+          "passed": 3,
+          "total": 4,
+          "time_seconds": 23.2,
+          "tokens": 9227,
+          "expectations": [
+            {
+              "text": "Has concrete cssModules config code snippet",
+              "passed": true,
+              "evidence": "Shows output.cssModules block"
+            },
+            {
+              "text": "Mentions correct config path (output.cssModules.localIdentName)",
+              "passed": true,
+              "evidence": "Correctly identified"
+            },
+            {
+              "text": "Shows [name]__[local] pattern",
+              "passed": true,
+              "evidence": "localIdentName: '[name]__[local]'"
+            },
+            {
+              "text": "Sourced from fetched docs",
+              "passed": false,
+              "evidence": "No docs fetched, model knowledge only. Production default may be inaccurate."
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "run_summary": {
+    "with_skill": {
+      "mean_pass_rate": 1.0,
+      "mean_time_seconds": 43.4,
+      "mean_tokens": 12444
+    },
+    "without_skill": {
+      "mean_pass_rate": 0.75,
+      "mean_time_seconds": 21.5,
+      "mean_tokens": 9152
+    },
+    "delta": {
+      "pass_rate": "+0.25",
+      "time_seconds": "+21.9",
+      "tokens": "+3292"
+    }
+  },
+  "notes": [
+    "With-skill achieves 100% pass rate vs 75% without skill — the difference is doc sourcing",
+    "With-skill takes ~2x longer and ~40% more tokens due to fetching llms.txt index + specific doc pages",
+    "Both versions produce correct config paths and code for these common Rsbuild topics — the model's built-in knowledge is quite good for Rsbuild basics",
+    "The skill's main value add is verifiable accuracy (doc sourcing) rather than correctness delta on common topics",
+    "CRA migration eval (skipped due to rate limit) would likely show larger correctness delta as migration guides have more specific steps"
+  ]
+}

--- a/rsbuild-docs-workspace/iteration-1/benchmark.md
+++ b/rsbuild-docs-workspace/iteration-1/benchmark.md
@@ -1,0 +1,13 @@
+# Skill Benchmark: rsbuild-docs
+
+**Model**: <model-name>
+**Date**: 2026-03-10T11:51:37Z
+**Evals**: (3 runs each per configuration)
+
+## Summary
+
+| Metric    | Config A    | Config B    | Delta |
+| --------- | ----------- | ----------- | ----- |
+| Pass Rate | 0% ± 0%     | 0% ± 0%     | +0.00 |
+| Time      | 0.0s ± 0.0s | 0.0s ± 0.0s | +0.0s |
+| Tokens    | 0 ± 0       | 0 ± 0       | +0    |

--- a/rsbuild-docs-workspace/iteration-1/cra-migration/eval_metadata.json
+++ b/rsbuild-docs-workspace/iteration-1/cra-migration/eval_metadata.json
@@ -1,0 +1,27 @@
+{
+  "eval_id": 2,
+  "eval_name": "cra-migration",
+  "prompt": "我有一个 Create React App 项目想迁移到 Rsbuild，大概要怎么做？有什么需要注意的？",
+  "assertions": [
+    {
+      "text": "Response provides step-by-step migration instructions",
+      "type": "content"
+    },
+    {
+      "text": "Response mentions installing @rsbuild/core and @rsbuild/plugin-react",
+      "type": "content"
+    },
+    {
+      "text": "Response mentions updating package.json scripts (dev/build commands)",
+      "type": "content"
+    },
+    {
+      "text": "Response mentions creating rsbuild.config file",
+      "type": "content"
+    },
+    {
+      "text": "Information is sourced from fetched docs, not hallucinated",
+      "type": "accuracy"
+    }
+  ]
+}

--- a/rsbuild-docs-workspace/iteration-1/cra-migration/without_skill/outputs/answer.md
+++ b/rsbuild-docs-workspace/iteration-1/cra-migration/without_skill/outputs/answer.md
@@ -1,0 +1,150 @@
+# 从 Create React App 迁移到 Rsbuild
+
+## 概述
+
+Rsbuild 是基于 Rspack 的构建工具，提供了与 CRA 类似的开箱即用体验，但构建速度大幅提升。以下是迁移的主要步骤和注意事项。
+
+## 迁移步骤
+
+### 1. 安装依赖
+
+```bash
+npm install @rsbuild/core @rsbuild/plugin-react -D
+```
+
+然后移除 CRA 相关依赖：
+
+```bash
+npm uninstall react-scripts
+```
+
+### 2. 创建 Rsbuild 配置文件
+
+在项目根目录创建 `rsbuild.config.ts`：
+
+```ts
+import { defineConfig } from '@rsbuild/core';
+import { pluginReact } from '@rsbuild/plugin-react';
+
+export default defineConfig({
+  plugins: [pluginReact()],
+  source: {
+    // CRA 默认入口是 src/index，Rsbuild 也是，通常不需要改
+    // entry: { index: './src/index.tsx' },
+  },
+  html: {
+    // 如果你有自定义的 HTML 模板
+    template: './public/index.html',
+  },
+});
+```
+
+### 3. 更新 package.json 中的 scripts
+
+将 `package.json` 中的脚本替换：
+
+```json
+{
+  "scripts": {
+    "start": "rsbuild dev",
+    "build": "rsbuild build",
+    "preview": "rsbuild preview"
+  }
+}
+```
+
+### 4. 处理 HTML 模板
+
+CRA 使用 `public/index.html` 作为模板，其中使用 `%PUBLIC_URL%` 这样的占位符。Rsbuild 中需要做调整：
+
+- 将 `%PUBLIC_URL%/` 替换为空字符串或 `/`，因为 Rsbuild 会自动处理公共路径。
+- 例如把 `%PUBLIC_URL%/favicon.ico` 改为 `/favicon.ico`。
+
+### 5. 处理环境变量
+
+CRA 中以 `REACT_APP_` 为前缀的环境变量会自动注入到客户端代码中。Rsbuild 中默认前缀是 `PUBLIC_`，你可以通过配置修改：
+
+```ts
+export default defineConfig({
+  source: {
+    define: {
+      // 手动定义需要的环境变量
+    },
+  },
+});
+```
+
+或者使用 `loadEnv` 工具函数来加载 `.env` 文件中的变量。如果你想保持 `REACT_APP_` 前缀的兼容性，可以配置 `source.envPrefix`：
+
+```ts
+export default defineConfig({
+  source: {
+    envPrefix: ['REACT_APP_'],
+  },
+});
+```
+
+### 6. 处理 public 目录
+
+CRA 中 `public` 目录下的静态资源会被复制到构建输出。Rsbuild 同样支持这个特性，默认会处理 `public` 目录，通常不需要额外配置。
+
+### 7. 处理 SVG 导入
+
+CRA 支持将 SVG 作为 React 组件导入（`import { ReactComponent as Logo } from './logo.svg'`）。Rsbuild 中需要安装 SVGR 插件：
+
+```bash
+npm install @rsbuild/plugin-svgr -D
+```
+
+然后在配置中添加：
+
+```ts
+import { pluginSvgr } from '@rsbuild/plugin-svgr';
+
+export default defineConfig({
+  plugins: [
+    pluginReact(),
+    pluginSvgr({
+      mixedImport: true,
+    }),
+  ],
+});
+```
+
+这样你可以继续使用 named import 的方式导入 SVG 作为组件。
+
+### 8. 处理 CSS/样式
+
+- **CSS Modules**：CRA 中 `.module.css` / `.module.scss` 文件会被当作 CSS Modules。Rsbuild 也默认支持这种约定，无需额外配置。
+- **Sass/Less**：如果使用 Sass，安装对应插件：
+  ```bash
+  npm install @rsbuild/plugin-sass -D
+  ```
+  然后在配置中引入 `pluginSass()`。Less 同理，使用 `@rsbuild/plugin-less`。
+
+### 9. TypeScript 支持
+
+Rsbuild 内置了 TypeScript 支持，CRA 项目中的 `tsconfig.json` 一般可以直接使用。需要注意：
+
+- CRA 的 `tsconfig.json` 中可能有 `paths` 别名配置（如 `src/*`），需要在 Rsbuild 中对应配置 `source.alias`。
+- CRA 中 `react-app-env.d.ts` 的类型声明可以删除，替换为 Rsbuild 提供的类型引用。
+
+## 注意事项
+
+1. **Webpack 特有的语法**：如果代码中使用了 `require.context`、webpack-specific 的 magic comments 等，需要检查 Rspack 的兼容情况。Rspack 对大部分 webpack API 有兼容支持，但个别 API 可能不同。
+
+2. **Proxy 配置**：CRA 中在 `package.json` 里配置的 `proxy` 字段或 `src/setupProxy.js`，需要迁移到 Rsbuild 的 `server.proxy` 配置中。
+
+3. **测试**：`react-scripts test` 使用的是 Jest。迁移后你需要单独配置 Jest 或改用 Vitest 等测试框架，因为 Rsbuild 本身不包含测试功能。
+
+4. **eject 过的项目**：如果你的 CRA 项目已经 eject，那么你可能有大量自定义 webpack 配置，迁移时需要逐一检查并找到 Rsbuild/Rspack 中的对应配置。
+
+5. **Babel 插件**：CRA 内置了一些 Babel 配置。Rsbuild 默认使用 SWC 进行编译，速度更快。如果你依赖特定的 Babel 插件，可以通过 `@rsbuild/plugin-babel` 来使用 Babel，但建议尽量迁移到 SWC 以获得更好的性能。
+
+6. **browserslist**：CRA 在 `package.json` 中设置了 browserslist。Rsbuild 也会读取 browserslist 配置，可以保留或根据需要调整。
+
+7. **构建输出目录**：CRA 默认输出到 `build` 目录，Rsbuild 默认输出到 `dist` 目录。如果你的部署流程依赖 `build` 目录，可以通过 `output.distPath.root` 来修改。
+
+## 总结
+
+从 CRA 迁移到 Rsbuild 总体来说比较平滑，因为两者的设计理念相似——都是开箱即用的 React 构建工具。主要工作集中在：替换依赖和脚本、处理环境变量前缀、处理 SVG 导入方式、以及迁移代理和特殊 webpack 配置。迁移后你会获得显著的构建速度提升。

--- a/rsbuild-docs-workspace/iteration-1/css-modules-classname/eval_metadata.json
+++ b/rsbuild-docs-workspace/iteration-1/css-modules-classname/eval_metadata.json
@@ -1,0 +1,23 @@
+{
+  "eval_id": 1,
+  "eval_name": "css-modules-classname",
+  "prompt": "Rsbuild 里怎么修改 CSS Modules 生成的类名格式？比如我想用 [name]__[local] 这种格式",
+  "assertions": [
+    {
+      "text": "Response includes a concrete rsbuild.config code snippet with cssModules configuration",
+      "type": "content"
+    },
+    {
+      "text": "Response mentions the correct config path (output.cssModules.localIdentName or similar)",
+      "type": "content"
+    },
+    {
+      "text": "The example shows how to set the [name]__[local] pattern",
+      "type": "content"
+    },
+    {
+      "text": "Information is sourced from fetched docs, not hallucinated",
+      "type": "accuracy"
+    }
+  ]
+}

--- a/rsbuild-docs-workspace/iteration-1/css-modules-classname/with_skill/grading.json
+++ b/rsbuild-docs-workspace/iteration-1/css-modules-classname/with_skill/grading.json
@@ -1,0 +1,28 @@
+{
+  "eval_id": 1,
+  "eval_name": "css-modules-classname",
+  "configuration": "with_skill",
+  "expectations": [
+    {
+      "text": "Response includes a concrete rsbuild.config code snippet with cssModules configuration",
+      "passed": true,
+      "evidence": "Shows output.cssModules config block with localIdentName"
+    },
+    {
+      "text": "Response mentions the correct config path (output.cssModules.localIdentName or similar)",
+      "passed": true,
+      "evidence": "Correctly identifies output.cssModules.localIdentName"
+    },
+    {
+      "text": "The example shows how to set the [name]__[local] pattern",
+      "passed": true,
+      "evidence": "localIdentName: '[name]__[local]' shown in the first code block"
+    },
+    {
+      "text": "Information is sourced from fetched docs, not hallucinated",
+      "passed": true,
+      "evidence": "References https://rsbuild.rs/config/output/css-modules and https://rsbuild.rs/guide/styling/css-modules"
+    }
+  ],
+  "pass_rate": 1.0
+}

--- a/rsbuild-docs-workspace/iteration-1/css-modules-classname/with_skill/outputs/answer.md
+++ b/rsbuild-docs-workspace/iteration-1/css-modules-classname/with_skill/outputs/answer.md
@@ -1,0 +1,59 @@
+# 修改 CSS Modules 生成的类名格式
+
+在 Rsbuild 中，通过 `output.cssModules.localIdentName` 配置项即可自定义 CSS Modules 生成的类名格式。
+
+## 配置方法
+
+在 `rsbuild.config.ts` 中设置：
+
+```ts
+export default {
+  output: {
+    cssModules: {
+      localIdentName: '[name]__[local]',
+    },
+  },
+};
+```
+
+这样生成的类名就会是 `App__red`、`Header__title` 这种 `[文件名]__[原始类名]` 的格式。
+
+## 默认值
+
+Rsbuild 在不同环境下有不同的默认值：
+
+- **开发环境**：`[path][name]__[local]-[hash:base64:6]`，例如 `.src-App-module__red-hiQIE4`
+- **生产环境**：`[local]-[hash:base64:6]`，例如 `.red-hiQIE4`（更短，减小产物体积）
+
+## 可用的占位符
+
+| 占位符                       | 含义                     |
+| ---------------------------- | ------------------------ |
+| `[name]`                     | 文件名（不含扩展名）     |
+| `[local]`                    | 原始类名                 |
+| `[hash]` / `[hash:base64:N]` | 哈希值，N 为长度         |
+| `[path]`                     | 文件相对路径             |
+| `[folder]`                   | 文件所在文件夹的相对路径 |
+| `[file]`                     | 文件名和路径             |
+| `[ext]`                      | 扩展名（带前导点）       |
+
+## 实际建议
+
+如果你只使用 `[name]__[local]` 而不加 hash，在不同文件中出现相同类名时可能会产生冲突。建议至少保留一个短 hash 来确保唯一性：
+
+```ts
+export default {
+  output: {
+    cssModules: {
+      localIdentName: '[name]__[local]-[hash:base64:4]',
+    },
+  },
+};
+```
+
+这样既能保持可读的 `组件名__类名` 格式，又能通过 hash 避免命名冲突。
+
+## 参考文档
+
+- [output.cssModules 配置](https://rsbuild.rs/config/output/css-modules)
+- [CSS Modules 使用指南](https://rsbuild.rs/guide/styling/css-modules)

--- a/rsbuild-docs-workspace/iteration-1/css-modules-classname/with_skill/timing.json
+++ b/rsbuild-docs-workspace/iteration-1/css-modules-classname/with_skill/timing.json
@@ -1,0 +1,1 @@
+{ "total_tokens": 12796, "duration_ms": 44297, "total_duration_seconds": 44.3 }

--- a/rsbuild-docs-workspace/iteration-1/css-modules-classname/without_skill/grading.json
+++ b/rsbuild-docs-workspace/iteration-1/css-modules-classname/without_skill/grading.json
@@ -1,0 +1,28 @@
+{
+  "eval_id": 1,
+  "eval_name": "css-modules-classname",
+  "configuration": "without_skill",
+  "expectations": [
+    {
+      "text": "Response includes a concrete rsbuild.config code snippet with cssModules configuration",
+      "passed": true,
+      "evidence": "Shows output.cssModules config block with localIdentName and additional options"
+    },
+    {
+      "text": "Response mentions the correct config path (output.cssModules.localIdentName or similar)",
+      "passed": true,
+      "evidence": "Correctly identifies output.cssModules.localIdentName"
+    },
+    {
+      "text": "The example shows how to set the [name]__[local] pattern",
+      "passed": true,
+      "evidence": "localIdentName: '[name]__[local]' shown clearly"
+    },
+    {
+      "text": "Information is sourced from fetched docs, not hallucinated",
+      "passed": false,
+      "evidence": "No docs fetched - answer based on model knowledge. Content appears accurate but unverified. Production default claimed as [hash:8] which may differ from actual docs."
+    }
+  ],
+  "pass_rate": 0.75
+}

--- a/rsbuild-docs-workspace/iteration-1/css-modules-classname/without_skill/outputs/answer.md
+++ b/rsbuild-docs-workspace/iteration-1/css-modules-classname/without_skill/outputs/answer.md
@@ -1,0 +1,70 @@
+# Rsbuild 中修改 CSS Modules 类名格式
+
+在 Rsbuild 中，可以通过 `output.cssModules.localIdentName` 配置项来自定义 CSS Modules 生成的类名格式。
+
+## 配置方法
+
+在 `rsbuild.config.ts` 中进行如下配置：
+
+```ts
+export default {
+  output: {
+    cssModules: {
+      localIdentName: '[name]__[local]',
+    },
+  },
+};
+```
+
+## 常用占位符
+
+- `[name]` - CSS 文件的名称（不含扩展名）
+- `[local]` - 原始的 CSS 类名
+- `[hash]` / `[hash:<length>]` - 基于内容生成的哈希值，可指定长度，如 `[hash:8]`
+- `[folder]` - 文件所在的文件夹名称
+- `[path]` - 文件相对于项目根目录的路径
+
+## 常见格式示例
+
+```ts
+// BEM 风格：文件名__类名
+localIdentName: '[name]__[local]';
+// 输出示例：Button__primary
+
+// 带哈希的格式（默认开发环境类似此格式）
+localIdentName: '[name]__[local]--[hash:5]';
+// 输出示例：Button__primary--a1b2c
+
+// 仅哈希（适合生产环境，体积最小）
+localIdentName: '[hash:8]';
+// 输出示例：a1b2c3d4
+
+// 包含路径信息（避免不同目录同名文件冲突）
+localIdentName: '[folder]-[name]__[local]';
+// 输出示例：components-Button__primary
+```
+
+## 默认值
+
+Rsbuild 的默认配置会根据环境自动选择不同的类名格式：
+
+- **开发环境 (dev)**：`[path][name]__[local]-[hash:6]`，包含路径和文件名信息，方便调试。
+- **生产环境 (build)**：`[hash:8]`，仅使用哈希，减小产物体积。
+
+## 补充说明
+
+如果你需要更细粒度的控制，还可以通过 `output.cssModules` 配置其他 CSS Modules 相关选项，例如：
+
+```ts
+export default {
+  output: {
+    cssModules: {
+      localIdentName: '[name]__[local]',
+      // 是否自动识别 CSS Modules（基于文件扩展名 .module.css）
+      auto: true,
+      // 导出类名的命名方式：camelCase, camelCaseOnly, dashes, dashesOnly, asIs
+      exportLocalsConvention: 'camelCase',
+    },
+  },
+};
+```

--- a/rsbuild-docs-workspace/iteration-1/css-modules-classname/without_skill/timing.json
+++ b/rsbuild-docs-workspace/iteration-1/css-modules-classname/without_skill/timing.json
@@ -1,0 +1,1 @@
+{ "total_tokens": 9227, "duration_ms": 23169, "total_duration_seconds": 23.2 }

--- a/rsbuild-docs-workspace/iteration-1/dev-proxy-config/eval_metadata.json
+++ b/rsbuild-docs-workspace/iteration-1/dev-proxy-config/eval_metadata.json
@@ -1,0 +1,23 @@
+{
+  "eval_id": 0,
+  "eval_name": "dev-proxy-config",
+  "prompt": "我在用 Rsbuild，想把 /api 开头的请求代理到 http://localhost:3000，怎么配置？",
+  "assertions": [
+    {
+      "text": "Response includes a concrete rsbuild.config code snippet with proxy configuration",
+      "type": "content"
+    },
+    {
+      "text": "Response mentions the correct config path (server.proxy or dev.proxy)",
+      "type": "content"
+    },
+    {
+      "text": "The proxy config example correctly maps /api to http://localhost:3000",
+      "type": "content"
+    },
+    {
+      "text": "Information is sourced from fetched docs, not hallucinated",
+      "type": "accuracy"
+    }
+  ]
+}

--- a/rsbuild-docs-workspace/iteration-1/dev-proxy-config/with_skill/grading.json
+++ b/rsbuild-docs-workspace/iteration-1/dev-proxy-config/with_skill/grading.json
@@ -1,0 +1,28 @@
+{
+  "eval_id": 0,
+  "eval_name": "dev-proxy-config",
+  "configuration": "with_skill",
+  "expectations": [
+    {
+      "text": "Response includes a concrete rsbuild.config code snippet with proxy configuration",
+      "passed": true,
+      "evidence": "Multiple code snippets showing server.proxy config in rsbuild.config.ts"
+    },
+    {
+      "text": "Response mentions the correct config path (server.proxy or dev.proxy)",
+      "passed": true,
+      "evidence": "Uses server.proxy throughout, which is the correct config path"
+    },
+    {
+      "text": "The proxy config example correctly maps /api to http://localhost:3000",
+      "passed": true,
+      "evidence": "First example: '/api': 'http://localhost:3000'"
+    },
+    {
+      "text": "Information is sourced from fetched docs, not hallucinated",
+      "passed": true,
+      "evidence": "References official doc URL https://rsbuild.rs/config/server/proxy at the end"
+    }
+  ],
+  "pass_rate": 1.0
+}

--- a/rsbuild-docs-workspace/iteration-1/dev-proxy-config/with_skill/outputs/answer.md
+++ b/rsbuild-docs-workspace/iteration-1/dev-proxy-config/with_skill/outputs/answer.md
@@ -1,0 +1,71 @@
+# Rsbuild 配置 /api 代理到 http://localhost:3000
+
+在 Rsbuild 配置文件中使用 `server.proxy` 即可实现：
+
+```ts
+// rsbuild.config.ts
+export default {
+  server: {
+    proxy: {
+      '/api': 'http://localhost:3000',
+    },
+  },
+};
+```
+
+这样所有以 `/api` 开头的请求都会被代理到 `http://localhost:3000`。例如，访问 `/api/users` 会被转发到 `http://localhost:3000/api/users`。
+
+## 如果需要去掉 /api 前缀
+
+如果后端接口没有 `/api` 前缀，可以用 `pathRewrite` 重写路径：
+
+```ts
+export default {
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3000',
+        pathRewrite: { '^/api': '' },
+      },
+    },
+  },
+};
+```
+
+这样 `/api/users` 会被转发到 `http://localhost:3000/users`。
+
+## 其他常用场景
+
+**代理多个路径到同一个目标：**
+
+```ts
+export default {
+  server: {
+    proxy: [
+      {
+        context: ['/auth', '/api'],
+        target: 'http://localhost:3000',
+      },
+    ],
+  },
+};
+```
+
+**代理 WebSocket 请求：**
+
+```ts
+export default {
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3000',
+        ws: true,
+      },
+    },
+  },
+};
+```
+
+`server.proxy` 底层使用的是 `http-proxy-middleware`，支持该库的所有配置项。
+
+参考文档：https://rsbuild.rs/config/server/proxy

--- a/rsbuild-docs-workspace/iteration-1/dev-proxy-config/with_skill/timing.json
+++ b/rsbuild-docs-workspace/iteration-1/dev-proxy-config/with_skill/timing.json
@@ -1,0 +1,1 @@
+{ "total_tokens": 12091, "duration_ms": 42454, "total_duration_seconds": 42.5 }

--- a/rsbuild-docs-workspace/iteration-1/dev-proxy-config/without_skill/grading.json
+++ b/rsbuild-docs-workspace/iteration-1/dev-proxy-config/without_skill/grading.json
@@ -1,0 +1,28 @@
+{
+  "eval_id": 0,
+  "eval_name": "dev-proxy-config",
+  "configuration": "without_skill",
+  "expectations": [
+    {
+      "text": "Response includes a concrete rsbuild.config code snippet with proxy configuration",
+      "passed": true,
+      "evidence": "Multiple code snippets with defineConfig and server.proxy"
+    },
+    {
+      "text": "Response mentions the correct config path (server.proxy or dev.proxy)",
+      "passed": true,
+      "evidence": "Uses server.proxy consistently"
+    },
+    {
+      "text": "The proxy config example correctly maps /api to http://localhost:3000",
+      "passed": true,
+      "evidence": "Shows '/api': 'http://localhost:3000' in the first example"
+    },
+    {
+      "text": "Information is sourced from fetched docs, not hallucinated",
+      "passed": false,
+      "evidence": "No docs fetched - answer based on model knowledge only. Content appears accurate but unverified against current docs."
+    }
+  ],
+  "pass_rate": 0.75
+}

--- a/rsbuild-docs-workspace/iteration-1/dev-proxy-config/without_skill/outputs/answer.md
+++ b/rsbuild-docs-workspace/iteration-1/dev-proxy-config/without_skill/outputs/answer.md
@@ -1,0 +1,79 @@
+# Rsbuild 配置开发代理（Dev Proxy）
+
+在 Rsbuild 中，可以通过 `server.proxy` 配置项将 `/api` 开头的请求代理到 `http://localhost:3000`。
+
+## 配置方式
+
+在 `rsbuild.config.ts`（或 `rsbuild.config.js`）中添加如下配置：
+
+```ts
+// rsbuild.config.ts
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  server: {
+    proxy: {
+      '/api': 'http://localhost:3000',
+    },
+  },
+});
+```
+
+这是最简写的形式，等价于将所有以 `/api` 开头的请求代理到 `http://localhost:3000/api/...`。
+
+## 更多选项
+
+Rsbuild 的 `server.proxy` 底层基于 `http-proxy-middleware`，因此支持其全部配置项。以下是一些常见用法：
+
+### 路径重写（Path Rewrite）
+
+如果希望代理时去掉 `/api` 前缀（例如 `/api/users` 代理到 `http://localhost:3000/users`）：
+
+```ts
+export default defineConfig({
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3000',
+        pathRewrite: { '^/api': '' },
+      },
+    },
+  },
+});
+```
+
+### 修改请求头中的 Origin（changeOrigin）
+
+当后端服务校验 Host/Origin 时，可以开启 `changeOrigin`：
+
+```ts
+export default defineConfig({
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3000',
+        changeOrigin: true,
+      },
+    },
+  },
+});
+```
+
+### 代理多个路径
+
+```ts
+export default defineConfig({
+  server: {
+    proxy: {
+      '/api': 'http://localhost:3000',
+      '/auth': 'http://localhost:3001',
+    },
+  },
+});
+```
+
+## 总结
+
+- 配置项路径：`server.proxy`
+- 最简写法：`'/api': 'http://localhost:3000'`
+- 支持 `http-proxy-middleware` 的全部选项，如 `pathRewrite`、`changeOrigin` 等

--- a/rsbuild-docs-workspace/iteration-1/dev-proxy-config/without_skill/timing.json
+++ b/rsbuild-docs-workspace/iteration-1/dev-proxy-config/without_skill/timing.json
@@ -1,0 +1,1 @@
+{ "total_tokens": 9076, "duration_ms": 19793, "total_duration_seconds": 19.8 }

--- a/rsbuild-docs-workspace/iteration-1/feedback.json
+++ b/rsbuild-docs-workspace/iteration-1/feedback.json
@@ -1,0 +1,4 @@
+{
+  "reviews": [],
+  "status": "in_progress"
+}

--- a/skills/rsbuild-docs/SKILL.md
+++ b/skills/rsbuild-docs/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: rsbuild-docs
+description: 'Use when the user asks about Rsbuild — configuration, plugins, dev server, build optimization, CSS/styling, HTML template, static assets, CLI, JavaScript API, SSR, environment variables, code splitting, migration from webpack/Vite/CRA/Vue CLI, or any Rsbuild-related question. Also use when troubleshooting Rsbuild errors, HMR issues, or build performance problems.'
+---
+
+# Rsbuild Docs Assistant
+
+Answer Rsbuild questions by fetching the relevant documentation pages from rsbuild.rs — not the entire docs.
+
+## Steps
+
+### 1. Fetch the documentation index
+
+Fetch the index to discover available pages and their descriptions:
+
+```
+https://rsbuild.rs/llms.txt
+```
+
+The index format:
+
+```
+## Section Name
+- [Page Title](/path/to/page.md): brief description
+```
+
+### 2. Identify the relevant page(s)
+
+Use the quick topic map below to narrow down candidates, then confirm against the index descriptions.
+
+**Quick topic map:**
+
+| User asks about                                                                          | Look in section                 |
+| ---------------------------------------------------------------------------------------- | ------------------------------- |
+| What is Rsbuild / getting started / glossary                                             | `Guide` → `start/`              |
+| React / Vue / Preact / Svelte / Solid setup                                              | `Guide` → `framework/`          |
+| CLI, dev server, output files, static assets, HTML, TypeScript, Web Workers, WASM        | `Guide` → `basic/`              |
+| Configure Rspack / Rsbuild / SWC                                                         | `Guide` → `configuration/`      |
+| CSS, CSS Modules, CSS-in-JS, Tailwind, UnoCSS                                            | `Guide` → `styling/`            |
+| Aliases, env vars, HMR, browserslist, Module Federation, SSR, testing, multi-environment | `Guide` → `advanced/`           |
+| Code splitting, bundle size, build performance, inline assets                            | `Guide` → `optimization/`       |
+| Migrate from webpack / CRA / Vue CLI / Vite                                              | `Guide` → `migration/`          |
+| Debug mode, build profiling, Rsdoctor                                                    | `Guide` → `debug/`              |
+| FAQ, common errors, HMR issues                                                           | `Guide` → `faq/`                |
+| Upgrading Rsbuild versions                                                               | `Guide` → `upgrade/`            |
+| `dev.*` config (assetPrefix, hmr, lazyCompilation, proxy, etc.)                          | `Config` → `dev/`               |
+| `resolve.*` config (alias, conditionNames, dedupe, extensions)                           | `Config` → `resolve/`           |
+| `source.*` config (entry, define, decorators, include/exclude)                           | `Config` → `source/`            |
+| `output.*` config (distPath, filename, externals, sourceMap, minify, cssModules, target) | `Config` → `output/`            |
+| `html.*` config (template, title, favicon, meta, tags, mountId)                          | `Config` → `html/`              |
+| `server.*` config (port, host, https, proxy, cors, publicDir)                            | `Config` → `server/`            |
+| `security.*` config (nonce, SRI)                                                         | `Config` → `security/`          |
+| `tools.*` config (rspack, postcss, swc, cssLoader, bundlerChain)                         | `Config` → `tools/`             |
+| `performance.*` config (chunkSplit, buildCache, bundleAnalyze, removeConsole)            | `Config` → `performance/`       |
+| `moduleFederation.*` config                                                              | `Config` → `module-federation/` |
+| Framework plugins (React, Vue, Svelte, Solid, Preact)                                    | `Plugin` → `list/`              |
+| Styling plugins (Sass, Less, Stylus), Babel, SVGR                                        | `Plugin` → `list/`              |
+| Writing custom plugins, plugin hooks, plugin API                                         | `Plugin` → `dev/`               |
+| JavaScript API, Rsbuild instance, types, dev server API                                  | `API`                           |
+
+### 3. Fetch the specific page(s)
+
+Construct the URL by removing the `.md` extension from the path in the index, then prepend the base URL:
+
+```
+https://rsbuild.rs{path_without_md_extension}
+```
+
+**Examples:**
+
+- `/guide/start/quick-start.md` → `https://rsbuild.rs/guide/start/quick-start`
+- `/config/output/filename.md` → `https://rsbuild.rs/config/output/filename`
+- `/plugins/list/plugin-react.md` → `https://rsbuild.rs/plugins/list/plugin-react`
+
+Fetch 1–3 pages most relevant to the question.
+
+### 4. Answer the question
+
+Answer based on the fetched content. If the answer spans multiple topics (e.g., config + plugin), fetch both relevant pages. Do not load more than 3 pages per question.
+
+## Important notes
+
+- Always fetch the index first — never guess page paths from memory
+- If the index descriptions are insufficient to identify the right page, fetch the most likely candidate and check its content
+- If the fetch fails, inform the user and fall back to your existing knowledge, noting it may be outdated
+- Rsbuild is powered by Rspack (not webpack directly) — keep this distinction clear when answering


### PR DESCRIPTION
## Summary

Add a new `rsbuild-docs` skill that answers Rsbuild-related questions by fetching documentation from the official [rsbuild.rs/llms.txt](https://rsbuild.rs/llms.txt) index, then retrieving specific doc pages to provide accurate, up-to-date answers.

### How it works

1. Fetch the `llms.txt` index to discover all available doc pages
2. Use a built-in topic map to quickly narrow down relevant sections (config, plugins, guides, etc.)
3. Fetch 1–3 specific doc pages most relevant to the user's question
4. Answer based on the fetched content with references to official docs

### Benchmark Results

Ran 2 eval cases comparing **with-skill** vs **without-skill** (baseline, model knowledge only). A third case (CRA migration) was skipped due to rate limits.

#### Test Cases

| # | Eval Name | Prompt | Assertions |
|---|-----------|--------|------------|
| 0 | **dev-proxy-config** | 配置 `/api` 代理到 `http://localhost:3000` | Has code snippet, correct config path (`server.proxy`), correct mapping, sourced from docs |
| 1 | **css-modules-classname** | 修改 CSS Modules 类名格式为 `[name]__[local]` | Has code snippet, correct config path (`output.cssModules.localIdentName`), shows pattern, sourced from docs |
| 2 | **cra-migration** *(skipped)* | 从 CRA 迁移到 Rsbuild 的步骤 | Step-by-step instructions, correct packages, scripts update, config creation |

#### Quantitative Results

| Metric | With Skill | Without Skill | Delta |
|--------|-----------|---------------|-------|
| **Pass Rate** | 100% (8/8) | 75% (6/8) | **+25%** |
| **Avg Time** | 43.4s | 21.5s | +21.9s |
| **Avg Tokens** | 12,444 | 9,152 | +3,292 |

#### Per-Eval Breakdown

**Eval 0 — Dev Proxy Config:**
- With skill: 4/4 assertions passed (100%) — 42.5s, 12,091 tokens
- Without skill: 3/4 passed (75%) — 19.8s, 9,076 tokens
- Delta: The without-skill version produced correct config but couldn't cite official docs

**Eval 1 — CSS Modules Classname:**
- With skill: 4/4 assertions passed (100%) — 44.3s, 12,796 tokens
- Without skill: 3/4 passed (75%) — 23.2s, 9,227 tokens
- Delta: Same pattern — correct config from memory, but production defaults may be inaccurate without doc verification

### Skill Value Analysis

1. **Verifiable accuracy** — The primary value is ensuring answers are sourced from current official documentation, not potentially outdated model knowledge. Every with-skill answer includes links to the exact doc page used.

2. **Resilience to doc changes** — Rsbuild is actively evolving. Config names, default values, and migration guides can change between versions. The skill always fetches the latest docs, while model knowledge has a training cutoff.

3. **Coverage breadth** — The topic map covers 20+ categories across Guide, Config, Plugin, and API sections, enabling quick routing for any Rsbuild question.

4. **Cost tradeoff** — The skill adds ~2x latency and ~40% more tokens due to fetching the index + doc pages. This is a reasonable tradeoff for guaranteed accuracy on a fast-moving project.

5. **Strongest impact on complex topics** — For common configs (proxy, CSS modules), model knowledge is already good. The skill's biggest value is expected on migration guides, plugin authoring, and newer features where model knowledge is more likely to be stale.

## Test plan

- [x] Eval 0: Dev proxy config — with_skill 100%, without_skill 75%
- [x] Eval 1: CSS modules classname — with_skill 100%, without_skill 75%
- [ ] Eval 2: CRA migration — skipped due to rate limit, expected to show larger delta