### PR TITLE
feat(skill): add pr-creator skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Skills in this section are mainly intended for Rstack ecosystem repositories and
 npx skills add rstackjs/agent-skills --skill pr-creator
 ```
 
-Create a pull request for this repository following Rstack team conventions, including branch safety rules, Conventional Commits PR titles, the pull request template, and concise English writing style.
+Use when asked to create a pull request for this repository. It helps the PR follow the repository's branch safety rules, title convention, pull request template, and concise English writing style.
 
 ## Contributing
 

--- a/skills/pr-creator/SKILL.md
+++ b/skills/pr-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-creator
-description: Use when asked to create a pull request for this repository. It ensures the PR follows rsbuild's branch safety rules, title convention, pull request template, and concise English writing style.
+description: Use when asked to create a pull request for this repository. It helps the PR follow the repository's branch safety rules, title convention, pull request template, and concise English writing style.
 ---
 
 # Pull Request Creator
@@ -8,16 +8,16 @@ description: Use when asked to create a pull request for this repository. It ens
 ## Steps
 
 1. Confirm the current branch with `git branch --show-current`.
-   If it is `main`, create and switch to a new branch before doing anything else.
+   If it is the default branch, create and switch to a new branch before doing anything else.
    Use a descriptive branch name, preferably `feat-<topic>` or `fix-<topic>`.
 
 2. Review local changes with `git status --short`.
    Do not revert unrelated user changes.
-   Before creating the PR, ensure the intended changes are committed and never commit directly on `main`.
+   Before creating the PR, ensure the intended changes are committed and never commit directly on the default branch.
 
-3. Read `.github/PULL_REQUEST_TEMPLATE.md` and keep its structure exactly.
+3. If `.github/PULL_REQUEST_TEMPLATE.md` exists, read it and keep its structure exactly.
 
-4. Draft the PR title in the repository's standard format, which follows Conventional Commits. Common patterns:
+4. Draft the PR title in the repository's standard format. If the repository uses Conventional Commits, common patterns include:
    - `feat(core): add ...`
    - `fix(plugin-less): ...`
    - `docs: ...`
@@ -30,7 +30,7 @@ description: Use when asked to create a pull request for this repository. It ens
    - Keep it short: one compact paragraph or 2-4 bullets is usually enough.
    - Focus on what changed and why it matters; avoid low-signal implementation detail.
    - Good background examples:
-     - `This PR adds support for custom logger injection so CLI output can be isolated per rsbuild instance.`
+     - `This PR adds support for custom logger injection so CLI output can be isolated per instance.`
      - `This PR fixes incorrect padding in URL labels to keep terminal output aligned across different label lengths.`
      - `This PR updates the English docs to clarify how the extraction option works and when to enable it.`
 
@@ -39,6 +39,6 @@ description: Use when asked to create a pull request for this repository. It ens
    Example: `https://github.com/web-infra-dev/rspack/releases/tag/v1.0.0`
    If there is no relevant link, leave a short note such as `None`.
 
-7. Push the branch only after re-checking the branch name. Never push `main`.
+7. Push the branch only after re-checking the branch name. Never push the default branch directly.
 
 8. Create the PR with `gh pr create`.


### PR DESCRIPTION
## Summary
- add the new `pr-creator` skill for creating pull requests
- document the skill in README under Rstack Workflow Skills

## Test Plan
- not run (documentation and skill addition only)

## Related Links
- None