### PR TITLE
docs: rename contribution workflow section

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A collection of Agent Skills for [Rstack](https://rspack.rs/guide/start/ecosyste
 - [Rsdoctor Skills](#rsdoctor-skills)
 - [Rstest Skills](#rstest-skills)
 - [Storybook Skills](#storybook-skills)
-- [Rstack Workflow Skills](#rstack-workflow-skills)
+- [Contribution Workflow Skills](#contribution-workflow-skills)
 - [Contributing](#contributing)
 - [License](#license)
 
@@ -197,9 +197,9 @@ npx skills add rstackjs/agent-skills --skill storybook-rsbuild
 
 Set up or migrate Storybook to use the Rsbuild builder. Handles fresh setup for React, Vue 3, HTML, Web Components, and React Native Web, migration from webpack5 or Vite frameworks, and integrations with Rslib, Modern.js, and Rspack.
 
-## Rstack Workflow Skills
+## Contribution Workflow Skills
 
-Skills in this section are mainly intended for Rstack ecosystem repositories and the Rstack team's workflow.
+Skills in this section are mainly intended for contribution workflows in repositories across the Rstack ecosystem.
 
 ### pr-creator
 


### PR DESCRIPTION
## Summary
- rename the README workflow section from Rstack Workflow Skills to Contribution Workflow Skills
- update the table of contents anchor to match the new section name
- broaden the section description to cover contribution workflows across the Rstack ecosystem

## Testing
- not run (docs-only change)