### PR TITLE
docs: update dependency tags

### DIFF
--- a/skills/rsbuild-v2-upgrade/SKILL.md
+++ b/skills/rsbuild-v2-upgrade/SKILL.md
@@ -21,7 +21,7 @@ description: Use when upgrading a Rsbuild 1.x project to v2, including dependenc
    - Note any removed or renamed options, defaults, or plugin APIs.
 
 4. **Update dependencies**
-   - Bump `@rsbuild/core` to v2 (currently Beta tag).
+   - Bump `@rsbuild/core` to v2 (currently `rc` tag).
    - Bump Rsbuild plugins to latest versions via `npx taze major --include /rsbuild/ -w -r`
 
 5. **Apply config and code changes**

--- a/skills/rspack-v2-upgrade/SKILL.md
+++ b/skills/rspack-v2-upgrade/SKILL.md
@@ -21,7 +21,7 @@ description: Use when upgrading a Rspack 1.x project to v2, including dependency
    - Note any removed or renamed options, defaults, or plugin APIs.
 
 4. **Update dependencies**
-   - Upgrade Rspack packages to v2 (currently Beta tag): `@rspack/core`, `@rspack/cli`, `@rspack/dev-server`.
+   - Upgrade Rspack packages to v2 (currently `rc` tag): `@rspack/core`, `@rspack/cli`, `@rspack/dev-server`.
 
 5. **Apply migration changes**
    - Update the Rspack config and related code according to the official guide.


### PR DESCRIPTION
This pull request updates the upgrade instructions for both Rsbuild and Rspack projects to reflect that their v2 packages are now at the "rc" (release candidate) stage instead of "Beta."