### PR TITLE
docs: update PR creator guidance

### DIFF
--- a/skills/pr-creator/SKILL.md
+++ b/skills/pr-creator/SKILL.md
@@ -15,7 +15,7 @@ description: Use when asked to create a pull request for this repository. It hel
    Do not revert unrelated user changes.
    Before creating the PR, ensure the intended changes are committed and never commit directly on the default branch.
 
-3. If `.github/PULL_REQUEST_TEMPLATE.md` exists, read it and keep its structure exactly.
+3. If `.github/PULL_REQUEST_TEMPLATE.md` exists, read it and follow its structure.
 
 4. Draft the PR title in the repository's standard format. If the repository uses Conventional Commits, common patterns include:
    - `feat(core): add ...`
@@ -26,9 +26,11 @@ description: Use when asked to create a pull request for this repository. It hel
    - `release: v1.2.0`
 
 5. Write the PR body in concise, clear English.
-   - In `Summary`, explain the user-facing problem or maintenance goal first, then the main change.
+   - In `Summary`, explain the change context first: the user-facing problem, maintenance goal, or compatibility constraint that makes the change necessary.
+   - Prioritize high-signal information: public API changes, behavior changes, breaking changes, migration notes, and important compatibility implications.
+   - Then describe the main implementation change only as much as needed to understand the review.
    - Keep it short: one compact paragraph or 2-4 bullets is usually enough.
-   - Focus on what changed and why it matters; avoid low-signal implementation detail.
+   - Avoid low-signal sections such as `Test plan`, routine verification commands, generated file lists, or obvious implementation details unless the repository template explicitly requires them or the change has unusual validation risk.
    - Good background examples:
      - `This PR adds support for custom logger injection so CLI output can be isolated per instance.`
      - `This PR fixes incorrect padding in URL labels to keep terminal output aligned across different label lengths.`
@@ -37,7 +39,7 @@ description: Use when asked to create a pull request for this repository. It hel
 6. Fill `Related Links` with issue links, design docs, related PRs, or discussion pages.
    If the PR upgrades an npm dependency, add a link to the upgraded version's release notes or tag page when available.
    Example: `https://github.com/web-infra-dev/rspack/releases/tag/v1.0.0`
-   If there is no relevant link, leave a short note such as `None`.
+   If there is no relevant link, omit the entire `Related Links` section from the PR body, including both the heading and its content.
 
 7. Push the branch only after re-checking the branch name. Never push the default branch directly.
 

--- a/skills/pr-creator/SKILL.md
+++ b/skills/pr-creator/SKILL.md
@@ -19,7 +19,7 @@ description: Use when asked to create a pull request for this repository. It hel
 
 4. Draft the PR title in the repository's standard format. If the repository uses Conventional Commits, common patterns include:
    - `feat(core): add ...`
-   - `fix(plugin-less): ...`
+   - `fix(types): ...`
    - `docs: ...`
    - `refactor(types): ...`
    - `chore(deps): ...`
@@ -39,7 +39,7 @@ description: Use when asked to create a pull request for this repository. It hel
 6. Fill `Related Links` with issue links, design docs, related PRs, or discussion pages.
    If the PR upgrades an npm dependency, add a link to the upgraded version's release notes or tag page when available.
    Example: `https://github.com/web-infra-dev/rspack/releases/tag/v1.0.0`
-   If there is no relevant link, omit the entire `Related Links` section from the PR body, including both the heading and its content.
+   If there is no relevant link, omit the entire `Related Links` section from the PR body.
 
 7. Push the branch only after re-checking the branch name. Never push the default branch directly.
 

--- a/skills/pr-creator/SKILL.md
+++ b/skills/pr-creator/SKILL.md
@@ -30,7 +30,7 @@ description: Use when asked to create a pull request for this repository. It hel
    - Prioritize high-signal information: public API changes, behavior changes, breaking changes, migration notes, and important compatibility implications.
    - Then describe the main implementation change only as much as needed to understand the review.
    - Keep it short: one compact paragraph or 2-4 bullets is usually enough.
-   - Avoid low-signal sections such as `Test plan`, routine verification commands, generated file lists, or obvious implementation details unless the repository template explicitly requires them or the change has unusual validation risk.
+   - Avoid low-signal sections such as `Test plan` or `Validation`, routine verification commands, generated file lists, or obvious implementation details unless the repository template explicitly requires them or the change has unusual validation risk.
    - Good background examples:
      - `This PR adds support for custom logger injection so CLI output can be isolated per instance.`
      - `This PR fixes incorrect padding in URL labels to keep terminal output aligned across different label lengths.`


### PR DESCRIPTION
## Summary

This PR tightens the PR creator skill guidance so generated PR descriptions prioritize review-relevant context and omit empty related-link sections when there are no useful references. It also relaxes template wording from keeping the structure exactly to following the structure, which gives agents room to avoid low-signal sections when the repository template does not require them.
