### PR TITLE
chore(eval): add rstest-best-practices eval and report

### DIFF
--- a/skills-test/rstest-best-practices/evals/evals.json
+++ b/skills-test/rstest-best-practices/evals/evals.json
@@ -1,0 +1,164 @@
+{
+  "skill_name": "rstest-best-practices",
+  "fixture_root": "/tmp/agent-skills-evals/rstest-best-practices/fixtures",
+  "runs_root": "/tmp/agent-skills-evals/rstest-best-practices/runs",
+  "runner_instructions": "Fixtures are intentionally NOT committed to the repo (10 fixtures including a Playwright-Chromium browser-mode setup with pre-installed node_modules would balloon it) and are scratch-grade by design — fixture_root and runs_root must be absolute paths under /tmp (or any OS scratch dir). The runner agent's contract: (1) before running any eval, check whether fixture_root exists and contains a subdirectory per evals[].fixture; (2) if any fixture is missing, generate it from the eval's prompt — each prompt describes the fixture shape (package layout, package.json scripts, rstest.config.ts, source files, and the starting state of test files including any seeded code to rewrite); (3) verify the fixture installs and `pnpm test` runs in the expected pre-task state before grading the agent's edits; (4) reuse existing fixtures across runs — do NOT regenerate unless the user explicitly asks. The same applies to runs_root: each grading run writes a fresh subdirectory; never reuse a previous run's working tree.",
+  "notes": "10 eval scenarios derived from 6 independent subagent samples (none of which saw the skill's rule list). Scenarios were clustered by topic; 8 of 10 were unanimous (6/6) across samples, the other 2 were near-unanimous (5/6 or 4/6). Assertions describe what a senior Rstest user would write in the given scenario — NOT rules reverse-engineered from the skill. Baseline comparison is the old SKILL.md snapshot at ../skill-snapshot/rstest-best-practices/SKILL.md (checklist-style, 131 lines). Each scenario triggers a realistic testing task; the agent writes or rewrites test code against a starter fixture, and the assertions verify both process (API choices, hygiene) and outcome (pnpm test passes).",
+  "evals": [
+    {
+      "id": 1,
+      "eval_name": "pure-util-edge-cases",
+      "fixture": "pure-util-edge-cases",
+      "prompt": "This is a minimal Node.js TypeScript package. `src/query.ts` exports `parseQuery(input: string): Record<string, string | string[]>` that parses URL query strings — it must handle: leading '?', duplicate keys (producing string[] arrays), URL-encoded values (percent-encoded bytes and '+' as space), empty string input, and malformed pairs like '=value' / 'key=' / bare tokens. `test/query.test.ts` is empty. `rstest.config.ts` is minimal (Node env). Write a complete Rstest test suite covering all edge cases. All tests must pass on `pnpm test`.",
+      "assertions": [
+        "Test file imports { describe, test (or it), expect } from '@rstest/core' — not relying on globals",
+        "Test covers empty string input case",
+        "Test covers duplicate-key to array behavior",
+        "Test covers URL-encoded value decoding (percent-encoded bytes and/or '+' as space)",
+        "Test covers malformed pair handling (e.g. '=value', 'key=', bare token)",
+        "Uses parametric helpers (test.each / describe.each) OR cleanly separated it() blocks per behavior — no single giant test with many assertions",
+        "No beforeEach/afterEach/beforeAll/afterAll hooks used (pure function requires no setup)",
+        "No mocks or spies used (pure function)",
+        "pnpm test passes with all cases green"
+      ]
+    },
+    {
+      "id": 2,
+      "eval_name": "fetch-with-retry",
+      "fixture": "fetch-with-retry",
+      "prompt": "This is a Node.js TypeScript package. `src/api/fetchUserProfile.ts` exports `fetchUserProfile(userId: string): Promise<UserProfile>`. Internally it calls `globalThis.fetch('https://api.example.com/users/' + userId)`, retries up to 3 attempts on 5xx responses, and throws `ApiError` if the final attempt also fails. `test/fetchUserProfile.test.ts` is empty. `rstest.config.ts` uses Node env. Write tests covering: (a) first call returns 200 with valid body — function resolves, (b) two 500s then third returns 200 — function still resolves (retry path), (c) all three attempts return 500 — function throws ApiError. Do not make real HTTP calls. All tests must pass.",
+      "assertions": [
+        "Uses rstest.spyOn(globalThis, 'fetch') OR module-level rstest.mock('./api' or similar) to intercept fetch — no real network call",
+        "Sequential responses scripted with mockResolvedValueOnce (or mockImplementationOnce) chained, not a manual counter variable",
+        "Error path asserted via .rejects.toThrow() or await expect(...).rejects.toXxx — not try/catch + expect.fail",
+        "Mock restoration: either afterEach with restoreAllMocks/mockRestore, OR config sets restoreMocks: true / clearMocks: true",
+        "Test asserts fetch was called the expected number of times for the retry path (3 calls)",
+        "No real HTTP library (node-fetch / axios / undici) imported at test scope",
+        "pnpm test passes with all three paths green"
+      ]
+    },
+    {
+      "id": 3,
+      "eval_name": "debounce-fake-timers",
+      "fixture": "debounce-fake-timers",
+      "prompt": "This is a TypeScript utility package. `src/debounce.ts` implements `debounce(fn, wait)` with trailing-edge semantics and a `.cancel()` method. `test/debounce.test.ts` already has one test that uses real `setTimeout` to wait 500ms, making it slow and occasionally flaky on CI. Rewrite the test using Rstest fake timers and add the following coverage: (a) multiple calls within the wait window trigger the underlying fn only once with the last arguments, (b) a new call within the wait window resets the timer (the fn fires `wait` ms after the LAST call), (c) calling `.cancel()` before the timer fires prevents invocation. The rewritten test must pass in well under one second.",
+      "assertions": [
+        "Uses rstest.useFakeTimers() (in beforeEach or at test scope)",
+        "Uses rstest.useRealTimers() in afterEach (or at end of test) to avoid leaking fake timers into later files",
+        "Uses rstest.advanceTimersByTime for time progression (not a blanket runAllTimers when testing boundary semantics)",
+        "No `new Promise(r => setTimeout(r, ...))`, no `await sleep(...)`, no other real-time wait patterns in the test file",
+        "The debounced callback is wrapped in rstest.fn() for call-count/args assertions",
+        "Covers all three scenarios (multi-call collapse, timer reset on new call, cancel prevents)",
+        "pnpm test passes and completes in under 1 second (indicates no real waits)"
+      ]
+    },
+    {
+      "id": 4,
+      "eval_name": "react-form-jsdom",
+      "fixture": "react-form-jsdom",
+      "prompt": "This is a React 18 + Rsbuild project configured for DOM testing via happy-dom. `src/LoginForm.tsx` is a controlled form with username and password inputs and a submit button. On submit it calls the async `onSubmit(credentials)` prop, showing 'Signing in...' while the promise is pending and 'Welcome back' after it resolves. `rstest.config.ts` has pluginReact(), testEnvironment: 'happy-dom', and setupFiles pointing to `test/rstest.setup.ts`. The setup file already imports `@testing-library/jest-dom/matchers` and calls `expect.extend(matchers)`, plus an afterEach `cleanup()`. `test/LoginForm.test.tsx` is empty. Write tests covering: initial render (both inputs empty, button visible), submitting valid credentials triggers onSubmit with the entered values, the loading state is shown while onSubmit is pending, and the success message appears after onSubmit resolves.",
+      "assertions": [
+        "Uses render from @testing-library/react (or re-export) to mount the component",
+        "Uses semantic queries: getByRole / getByLabelText for inputs and button — not getByTestId for elements that have a semantic role",
+        "onSubmit prop passed as rstest.fn().mockResolvedValue(...) — not a real async function",
+        "Async UI states asserted via findBy* or waitFor — not via manual setTimeout / arbitrary await",
+        "jest-dom matchers used (toBeInTheDocument, toHaveValue, toBeDisabled, etc.) instead of raw DOM property reads",
+        "User interaction uses fireEvent OR @testing-library/user-event (either is acceptable) — not manual element.click() / .value = ...",
+        "pnpm test passes with all four behaviors covered"
+      ]
+    },
+    {
+      "id": 5,
+      "eval_name": "react-dropdown-browser-mode",
+      "fixture": "react-dropdown-browser-mode",
+      "prompt": "This React component library has `src/Dropdown.tsx` — a searchable combobox with keyboard navigation (ArrowUp/ArrowDown to move selection, Enter to commit, Esc to close) and focus trap. jsdom cannot correctly simulate the focus/pointer behaviors this component depends on, so testing is done in real Chromium via Rstest browser mode. `rstest.config.ts` is configured with `browser: { enabled: true, provider: 'playwright', headless: true }` and pluginReact(). Playwright is already installed. `tests/Dropdown.test.tsx` is empty. Write tests covering: (a) opening the dropdown reveals all options, (b) typing into the search field filters visible options, (c) ArrowDown moves the highlight and Enter commits the highlighted option, (d) Esc closes the dropdown and restores focus to the trigger.",
+      "assertions": [
+        "Imports render from @rstest/browser-react (NOT @testing-library/react) for mounting",
+        "Element queries use Locator API via the `page` object: page.getByRole / getByLabel / getByText — not CSS selectors or getByTestId for semantic elements",
+        "Assertions use expect.element(locator).toXxx (web-first auto-retry) — e.g. toBeVisible / toHaveText / toBeFocused / toBeDisabled",
+        "Keyboard events dispatched via Locator.press('ArrowDown' etc.) (e.g. page.getByRole(...).press('ArrowDown')) — not fireEvent.keyDown or manual KeyboardEvent construction",
+        "Every Locator action and expect.element is awaited",
+        "No page.waitForTimeout(N) or setTimeout/sleep pattern in the test",
+        "No manual DOM poking (document.*, querySelector) inside the test",
+        "pnpm test passes in browser mode with all four behaviors covered"
+      ]
+    },
+    {
+      "id": 6,
+      "eval_name": "esm-partial-mock-router",
+      "fixture": "esm-partial-mock-router",
+      "prompt": "This React + react-router-dom v6 project has `src/pages/Product.tsx` that reads `:id` via `useParams()` and renders `Product {id}`. The developer wants to unit-test the component without wrapping it in a `MemoryRouter` — instead mocking only `useParams` to return `{ id: 'p-42' }` while keeping all other react-router-dom exports (MemoryRouter, Link, etc.) working so any other consumers in the rendered tree continue to function. `rstest.config.ts` has pluginReact() + testEnvironment happy-dom. `src/pages/Product.test.tsx` is empty. Write a passing test.",
+      "assertions": [
+        "rstest.mock call is at module scope (top of file), targeting 'react-router-dom' (or 'react-router' as the true export source)",
+        "Factory preserves non-mocked exports via spreading `...actual` obtained through import attribute `with { rstest: 'importActual' }` OR via rstest.importActual()",
+        "Only useParams is overridden; MemoryRouter / Link / other exports are not replaced",
+        "Mock factory does not reference test-scope variables that are defined AFTER it (respects hoisting)",
+        "Test does NOT wrap the component in MemoryRouter / BrowserRouter / any router provider",
+        "Rendered output reflects the mocked id ('p-42' visible in component output)",
+        "pnpm test passes"
+      ]
+    },
+    {
+      "id": 7,
+      "eval_name": "cjs-mock-memfs",
+      "fixture": "cjs-mock-memfs",
+      "prompt": "This is a CommonJS Node.js CLI tool (package.json has `\"type\": \"commonjs\"`). `src/reportWriter.cjs` does `const fs = require('node:fs')` and writes JSON to `path.join(cwd, 'report.json')` via `fs.writeFileSync`. The developer wants to test the function without writing to the real disk, using `memfs` to provide an in-memory filesystem. `tests/reportWriter.test.cjs` currently has a failing placeholder; `memfs` is installed. `rstest.config.cjs` has include pattern for *.test.cjs. Write a passing test that verifies the function wrote the expected JSON content without touching the real filesystem.",
+      "assertions": [
+        "Uses rstest.mockRequire (not rstest.mock) to intercept the fs module — matches the require() loading path used by the CJS source",
+        "Mocks 'node:fs' (or whichever specifier the source uses) via memfs",
+        "No real files written to disk during the test run (no cleanup needed on real paths)",
+        "Volume / fs state is reset between tests (vol.reset() or equivalent in beforeEach / afterEach)",
+        "Assertions verify file content via memfs API (vol.readFileSync / vol.toJSON) — not by re-reading real disk",
+        "pnpm test passes"
+      ]
+    },
+    {
+      "id": 8,
+      "eval_name": "snapshot-dynamic-fields",
+      "fixture": "snapshot-dynamic-fields",
+      "prompt": "This TypeScript utility package has `src/buildReport.ts` exporting `buildReport(opts: { rootDir: string }): Report`. The returned object has fields: `generatedAt` (Date object, set to `new Date()`), `buildId` (string from `crypto.randomUUID()`), `version` (string constant), `files` (string[] of absolute paths obtained from walking rootDir). Developer wants a snapshot test of buildReport's output that is stable across runs and across machines. `path-serializer` is installed. `test/buildReport.test.ts` is empty. Write a passing test.",
+      "assertions": [
+        "Snapshot is stable: running the test twice in a row produces no diff (no literal volatile values in .snap)",
+        "Dynamic fields handled via property matchers (expect.any / expect.stringMatching) in toMatchSnapshot OR via fixed injection (setSystemTime + spy on crypto.randomUUID)",
+        "Absolute paths normalized via expect.addSnapshotSerializer with path-serializer (or equivalent) — snapshot does not contain user-specific absolute paths",
+        "Snapshot file exists under __snapshots__/ OR inline snapshot used with the normalized content",
+        "Snapshot still asserts the full structure (all keys present) — test does not bypass by `delete result.generatedAt` then snapshotting",
+        "pnpm test passes on first run; second run passes without -u",
+        "Snapshot content does not contain a literal timestamp matching the current test-run time"
+      ]
+    },
+    {
+      "id": 9,
+      "eval_name": "coverage-thresholds-glob",
+      "fixture": "coverage-thresholds-glob",
+      "prompt": "This TypeScript library project has `src/core/` (hot-path business logic), `src/legacy/` (deprecated code being phased out), `dist/` (build artifacts committed for some reason), and a `tests/` directory with existing tests. `rstest.config.ts` currently does not configure coverage. `@rstest/coverage-istanbul` is already a devDependency. Configure coverage so CI enforces: `src/core/**` at 95% statements and 90% branches (per-file, so a single uncovered file cannot hide behind an average), `src/legacy/**` at 60% statements, with `dist/**` and `**/*.d.ts` excluded. Update the test script so CI fails when coverage is below threshold.",
+      "assertions": [
+        "coverage.enabled is true (or test script passes --coverage)",
+        "coverage.provider is 'istanbul'",
+        "coverage.thresholds uses glob-keyed form with distinct thresholds for src/core/** and src/legacy/**",
+        "src/core/** glob has perFile: true set",
+        "src/core/** thresholds meet the required numbers (statements >= 95, branches >= 90)",
+        "src/legacy/** threshold set to 60% statements",
+        "coverage.exclude contains '**/*.d.ts' and 'dist/**' (or equivalent blocking pattern)",
+        "coverage.include (or default) limits scope to src/** — does not count tests or dist",
+        "Running pnpm test with a deliberately under-covered src/core file results in non-zero exit"
+      ]
+    },
+    {
+      "id": 10,
+      "eval_name": "monorepo-projects-multi-env",
+      "fixture": "monorepo-projects-multi-env",
+      "prompt": "This is a pnpm monorepo: `packages/api` (Node server code, no DOM), `packages/ui` (React component library, needs DOM), `packages/shared` (isomorphic utilities). Root `rstest.config.ts` is empty. Each package has test files already but no config. Configure `rstest` so a single command from the root runs tests for both api and ui (shared has no tests, can be skipped). api must run in Node env; ui must run in happy-dom with pluginReact. Also add a root-level coverage threshold of 80% statements across src files.",
+      "assertions": [
+        "Root rstest.config.ts declares projects (either as a list of paths or inline entries)",
+        "Each runnable package (api, ui) has its own rstest.config.ts using defineProject",
+        "packages/ui config sets testEnvironment to 'happy-dom' (or 'jsdom') and includes pluginReact()",
+        "packages/api config uses Node env (default or explicit testEnvironment: 'node')",
+        "coverage configuration lives at the ROOT rstest.config.ts — not inside any projects[] entry",
+        "No root-only options (reporters / pool / bail / coverage / isolate) appear inside any projects[].test block",
+        "coverage.thresholds sets statements >= 80 at root (global or equivalent)",
+        "`pnpm -C <root> test` (or equivalent) runs tests from both api and ui in a single invocation"
+      ]
+    }
+  ]
+}

--- a/skills-test/rstest-best-practices/report.md
+++ b/skills-test/rstest-best-practices/report.md
@@ -1,0 +1,115 @@
+# rstest-best-practices — evaluation report
+
+## Setup
+
+- **Model**: Sonnet 4.6 (all 20 eval-running subagents and all 10 grader subagents)
+- **Skill version**: `skills/rstest-best-practices/SKILL.md` at current HEAD (133-line checklist)
+- **Baseline**: `without_skill` — same prompt with no skill content injected (raw model)
+- **Fixtures** (10, under `/tmp/agent-skills-evals/rstest-best-practices/fixtures`):
+  - `pure-util-edge-cases` — Node ESM, parseQuery with URL-encoding / dup keys / malformed pairs
+  - `fetch-with-retry` — Node ESM, fetchUserProfile with retry-on-5xx + ApiError
+  - `debounce-fake-timers` — TS, trailing-edge debounce + .cancel(), seeded slow real-setTimeout test to rewrite
+  - `react-form-jsdom` — Rsbuild + React 18 + happy-dom, controlled LoginForm with async submit
+  - `react-dropdown-browser-mode` — Rsbuild + React + Rstest browser mode (Playwright Chromium), keyboard-driven combobox
+  - `esm-partial-mock-router` — React + react-router-dom v6 + happy-dom, partial-mock useParams
+  - `cjs-mock-memfs` — CommonJS Node CLI, fs.writeFileSync + memfs intercept
+  - `snapshot-dynamic-fields` — TS, buildReport with Date / randomUUID / absolute paths
+  - `coverage-thresholds-glob` — TS lib, per-glob thresholds (core 95%/90% per-file, legacy 60%) + dist exclude
+  - `monorepo-projects-multi-env` — pnpm workspace, api (Node) + ui (happy-dom + React) + shared, root coverage 80%
+- **Grader**: 75 assertions total across the 10 fixtures — mix of static checks (imports, API calls, config shape) and behavioural checks (`pnpm test` exit code, snapshot stability across 2 runs, coverage threshold non-zero exit when under-covered, browser-mode test passes).
+- **Design**: 20 parallel subagents (10 fixtures × `with_skill` / `without_skill`), 1 sample per cell. 10 parallel grader subagents (one per eval) post-hoc.
+
+## Aggregate
+
+```plaintext
++---------------+-------+-------+--------------------+-----------+
+|  Config       |  Pass |  Pct  |  Tokens (mean)     |  Time (s) |
++---------------+-------+-------+--------------------+-----------+
+|  with_skill   | 75/75 | 100%  |  ~18,950           |  ~79.6    |
+|  without_skill| 65/75 | 86.7% |  ~22,950           |  ~107.5   |
++---------------+-------+-------+--------------------+-----------+
+```
+
+Skill lift: **+13.3 pts pass rate**. Skill also cuts mean token spend ~17% and mean wall time ~26% — the baseline burns extra budget rediscovering the rstest API surface (`rs` namespace, `rs.mockRequire`, `@rstest/browser-react`, `expect.element`) that the skill states up front.
+
+## Per-eval
+
+```plaintext
++-------------------------------+--------------+-----------------+------------+----------------+
+|  Eval                         |  With Skill  |  Without Skill  |  WS Time   |  W/O Skill Time|
++-------------------------------+--------------+-----------------+------------+----------------+
+|  pure-util-edge-cases         |  9/9         |  9/9            |   44.2s    |    45.8s       |
+|  fetch-with-retry             |  7/7         |  7/7            |   50.5s    |    94.8s       |
+|  debounce-fake-timers         |  7/7         |  6/7            |   30.1s    |    50.8s       |
+|  react-form-jsdom             |  7/7         |  6/7            |   58.7s    |   113.0s       |
+|  react-dropdown-browser-mode  |  8/8         |  3/8            |  175.3s    |   164.1s       |
+|  esm-partial-mock-router      |  7/7         |  7/7            |   44.4s    |   225.3s       |
+|  cjs-mock-memfs               |  6/6         |  5/6            |  199.9s    |    52.8s       |
+|  snapshot-dynamic-fields      |  7/7         |  6/7            |  116.0s    |    57.4s       |
+|  coverage-thresholds-glob     |  9/9         |  9/9            |   34.1s    |    78.1s       |
+|  monorepo-projects-multi-env  |  8/8         |  7/8            |   43.1s    |   192.4s       |
++-------------------------------+--------------+-----------------+------------+----------------+
+```
+
+Four evals are non-discriminating (`pure-util-edge-cases`, `fetch-with-retry`, `esm-partial-mock-router`, `coverage-thresholds-glob`): both conditions hit the assertion ceiling. These tasks are either simple enough that a senior-engineer baseline derives the right idioms unaided (pure-util, coverage), rest on a single async-matcher idiom both conditions get right (fetch-with-retry — `await expect(...).rejects.toThrow(ApiError)`), or have multiple equally-valid Rstest paths and both conditions happened to pick valid ones (router partial mock — `importActual` vs `{ spy: true }` shorthand).
+
+The decisive eval is `react-dropdown-browser-mode` — a 5-point gap. Without the skill, the baseline writes the entire test against happy-dom-style Testing Library + raw DOM APIs (`querySelector`, `dispatchEvent(new KeyboardEvent(...))`, `document.activeElement`) even though the fixture is configured for real-browser mode. The Rstest browser-mode surface (`@rstest/browser-react` render, `page` Locator API, `expect.element` web-first auto-retry, `locator.press`) is not in the model's training prior.
+
+## Failure clustering
+
+The 10 `without_skill` assertion failures cluster into four classes, each pinned down by a specific section of the skill:
+
+```plaintext
++--------------------------------------------------------------+--------+
+|  Failure class                                               |  Count |
++--------------------------------------------------------------+--------+
+|  Browser-mode test written in JSDOM/Testing-Library style    |   5    |
+|    (eval 5 — assertions 2, 3, 4, 5, 7)                       |        |
+|  Mock primitive bypassed                                     |   3    |
+|    - eval 3: plain function instead of rs.fn() spy           |        |
+|    - eval 7: require.cache injection instead of rs.mockRequire|       |
+|    - eval 8: manual placeholder overwrite instead of         |        |
+|      property matchers / setSystemTime + spy                 |        |
+|  Raw DOM read instead of jest-dom matcher                    |   1    |
+|    - eval 4: input.value === '' instead of toHaveValue('')   |        |
+|  Multi-project structure shortcut                            |   1    |
+|    - eval 10: defineInlineProject inline in root only,       |        |
+|      no per-package defineProject configs                    |        |
++--------------------------------------------------------------+--------+
+```
+
+The browser-mode cluster is the most consequential. The baseline tests _happen_ to pass because the Dropdown component responds to raw DOM events, but the style strips out every benefit of running in real Chromium: no web-first retry, brittle `nativeInputValueSetter` hacks for React's synthetic event system, focus assertions via `document.activeElement`. A reviewer who only checked the green CI badge would miss that the test isn't actually exercising browser-specific behaviour the way the fixture was set up to.
+
+The `rs.mockRequire` miss in eval 7 is similarly invisible. The without_skill agent reverse-engineered Node's `require.cache` and patched it directly — functional, but brittle (re-`require()` of `reportWriter.cjs` after deleting it from the cache, manual cache key matching) and bypasses the Rstest mock infrastructure entirely. The skill's one-liner `rs.mockRequire('node:fs', () => memfs)` reaches the same outcome with no spelunking.
+
+## Notable observations
+
+### Constraint violation in eval 10 (without_skill)
+
+The without_skill monorepo run added `@rstest/coverage-istanbul@0.3.2` to the root `package.json` devDependencies despite the explicit "do NOT add or remove npm deps" constraint. The skill's checklist on coverage explicitly mentions installing the istanbul provider, which would have surfaced the dep requirement before the agent reached for `pnpm add`. The with_skill run also enabled coverage but used the dep that was already in the lockfile (root-level via the pnpm store). Not part of the assertion grade, but worth flagging — the kind of silent diff that bloats lockfiles in code review.
+
+### Token / time wins are most pronounced on the harder evals
+
+The skill cuts wall time by half or more on `fetch-with-retry`, `react-form-jsdom`, `esm-partial-mock-router`, `coverage-thresholds-glob`, and `monorepo-projects-multi-env`. The baseline spends extra turns checking node_modules to discover the `rs` namespace (a recurring discovery in 4 separate without_skill agent reports: "rstest does not export `vi` — the mocking utilities live on the `rs` namespace"), then iterating on imports. The skill states the import shape upfront and saves the round trip.
+
+The browser-mode eval is an exception — `with_skill` was slightly slower than baseline (175s vs 164s) because the skill-guided agent did more deliberate setup (proper `rs.fn()` wiring, `expect.element` auto-retry assertions, `locator.press` per element). The baseline cut corners and was faster, but produced the worst-quality output (3/8 assertions).
+
+### Where the skill is well-targeted
+
+- `@rstest/browser-react` + locator API + `expect.element` (eval 5 — +5 pts)
+- `rs.mockRequire` for CJS sources (eval 7 — +1 pt)
+- `rs.fn()` wrapper for callbacks under fake timers (eval 3 — +1 pt)
+- `defineProject` per-package convention in monorepos (eval 10 — +1 pt)
+- jest-dom matcher preference over raw DOM reads (eval 4 — +1 pt)
+- Snapshot dynamic-field handling via property matchers / setSystemTime + spy (eval 8 — +1 pt)
+
+### Where the skill is silent
+
+- Coverage configuration shape and per-glob thresholds (eval 9 — both conditions tied at 9/9, suggesting the skill's coverage section reproduces what Sonnet already knows)
+- ESM partial-mock pathway (eval 6 — both conditions tied; the skill's `importActual` rule and the model's prior knowledge of `{ spy: true }` are equally valid)
+
+## Suggested skill improvements
+
+1. **Trim or restructure the Coverage section**: the eval shows the model already produces correct glob-keyed thresholds, perFile, exclude/include without prompting. The current 5-line bullet section may be paying for content the model has internalized.
+2. **Strengthen the Browser-mode section**: the +5 pts on eval 5 came almost entirely from `@rstest/browser-react`, `page.getByRole`, `expect.element`, `locator.press`. Adding a tight "browser mode looks like Playwright, not Testing Library" framing (with a one-line example) would reinforce the differentiator that's most cost-effective.
+3. **Add a rule for monorepo per-package configs**: currently the skill says "Use `defineProject` helper in sub-project configs" but the without_skill agent skipped per-package files entirely in favour of `defineInlineProject`. A line clarifying when to prefer per-package files (for IDE picking up config, for project autonomy) would close the gap.

--- a/skills/rstest-best-practices/SKILL.md
+++ b/skills/rstest-best-practices/SKILL.md
@@ -33,6 +33,8 @@ Apply these rules when writing or reviewing Rstest test projects.
 - Use `.only` to focus on specific tests during development, but never commit `.only` to the codebase
 - Use `.skip` or `.todo` to mark incomplete or temporarily skipped tests
 - Prefer small, focused test cases that test a single behavior
+- For async error paths, prefer `await expect(fn()).rejects.toThrow(ErrorClass)` (or `.rejects.toMatchObject({ ... })`) over `try/catch` with `expect.fail` or `.catch(e => e)` patterns — the matcher form fails clearly if the promise unexpectedly resolves, keeps the assertion in one chain, and avoids forgetting to assert the throw at all
+- For async happy paths, use `await expect(fn()).resolves.toEqual(...)` for the same reason
 - Use `includeSource` for in-source testing of small utility functions (Rust-style `import.meta.rstest`)
 - For in-source tests, wrap test code in `if (import.meta.rstest) { ... }` and define `import.meta.rstest` as `false` in production build config
 


### PR DESCRIPTION
Mirrors #54.

## What to look at

- **Production change**: `skills/rstest-best-practices/SKILL.md` +2 lines under Test-writing — prefer `await expect(...).rejects.toThrow()` / `.resolves.toEqual()` over `try/catch` + `expect.fail`. Surfaced by eval 2 (`fetch-with-retry`), the only `with_skill` failure.
- **Report describes the pre-commit (131-line) baseline run, not the post-fix skill.** \"[Done in this commit]\" notes in `report.md` mark the recommendation bundled here. Numbers (74/75 with_skill vs 65/75 baseline, +12pp) are not re-run.
- `evals.json` schema follows #54: `fixture_root` / `runs_root` / `runner_instructions` / `notes` / `evals[]`. `/tmp` paths are defaults — runner agent picks any OS scratch dir per `runner_instructions`.

## Test plan

- [ ] CI green