### PR TITLE
chore(eval): add storybook-rsbuild eval and report

### DIFF
--- a/skills-test/storybook-rsbuild/evals/evals.json
+++ b/skills-test/storybook-rsbuild/evals/evals.json
@@ -1,0 +1,374 @@
+{
+  "skill_name": "storybook-rsbuild",
+  "fixture_root": "/tmp/agent-skills-evals/storybook-rsbuild/fixtures",
+  "runs_root": "/tmp/agent-skills-evals/storybook-rsbuild/runs",
+  "runner_instructions": "Fixtures are intentionally NOT committed to the repo (10 fixtures including a pnpm monorepo and several Vite/Rsbuild apps with installed node_modules would balloon it) and are scratch-grade by design — fixture_root and runs_root must be absolute paths under /tmp (or any OS scratch dir). The runner agent's contract: (1) before running any eval, check whether fixture_root exists and contains a subdirectory per evals[].fixture; (2) if any fixture is missing, generate it from that eval's pre_run_baseline (project_kind, ui_framework, builder/integration, key files and their seeded contents, package.json scripts) plus the top-level notes — both fields together fully describe the fixture shape; (3) for migration / already-set-up fixtures, verify that `pnpm install` succeeds and `pnpm storybook --ci` (or `pnpm build-storybook`) runs in the expected pre-task state before grading; for fresh-setup / integration fixtures, verify that the host app's existing `pnpm dev` / `pnpm build` still works pre-task; (4) reuse existing fixtures across runs — do NOT regenerate unless the user explicitly asks. The same applies to runs_root: each grading run writes a fresh subdirectory; never reuse a previous run's working tree.",
+  "notes": "10 scenarios mapped 1:1 onto the SKILL.md decision tree: fresh setup (React/Vanilla/Web Components), migration (react-vite, react-webpack5, vue3-vite), integration overlay (Rslib, Modern.js, Pure Rspack), and monorepo partial migration. Storybook major versions are intentionally varied (8, 9, 10) across migration fixtures so the agent must consult the version-compatibility table at https://storybook.rsbuild.rs/guide/migration and pick the matching storybook-rsbuild major (v10→^3, v9→^2, v8→^1). Fresh-setup fixtures pin no Storybook deps so the agent installs the latest stable matching pair. Migration fixtures keep working pre-task: tests assert that the agent does not delete legacy framework deps before the new builder is verified. Every fixture's existing app `pnpm dev` / `pnpm build` must remain green post-task — touching business source files is a red line.",
+  "evals": [
+    {
+      "id": 1,
+      "eval_name": "react-vite-migration",
+      "fixture": "react-vite-migration",
+      "pre_run_baseline": {
+        "project_kind": "single-package app",
+        "ui_framework": "React 18 + TypeScript",
+        "host_builder": "Vite 5",
+        "package_manager": "pnpm",
+        "storybook_version": "8.6.x",
+        "current_storybook_framework": "@storybook/react-vite",
+        "storybook_devDeps": [
+          "storybook@^8.6.0",
+          "@storybook/react-vite@^8.6.0",
+          "@storybook/react@^8.6.0",
+          "@storybook/addon-essentials@^8.6.0",
+          "@storybook/addon-links@^8.6.0",
+          "@storybook/blocks@^8.6.0"
+        ],
+        "key_files": [
+          ".storybook/main.ts — framework: '@storybook/react-vite', viteFinal sets resolve.alias for @app and @components via path.resolve(__dirname, '../src/...')",
+          ".storybook/preview.ts — minimal preview parameters",
+          "src/Button.tsx + src/Button.stories.tsx — one working CSF3 story importing from @app/utils",
+          "vite.config.ts — host app config with the same @app/@components aliases",
+          "package.json scripts: storybook=storybook dev -p 6006, build-storybook=storybook build"
+        ]
+      },
+      "prompt": "Migrate this Vite + React 18 + TypeScript project's Storybook from @storybook/react-vite to the Rsbuild builder. The .storybook/main.ts has a viteFinal hook that adds @app and @components path aliases via path.resolve(__dirname, '../src/...'). Keep the existing addons (@storybook/addon-essentials, @storybook/addon-links) and the Button story working post-migration. The host app's vite.config.ts and src/ files must not be modified. Storybook is pinned to 8.6.x — pick the storybook-react-rsbuild major that matches per the upstream version-compatibility table.",
+      "assertions": [
+        "package.json removes @storybook/react-vite (and @storybook/builder-vite if listed)",
+        "package.json adds storybook-react-rsbuild with a version range matching Storybook v8 (^1) — NOT ^2 or ^3",
+        "package.json adds @rsbuild/core (>=1.0.1) as devDep",
+        ".storybook/main.ts framework field changed to 'storybook-react-rsbuild' (string form, not the @storybook/* form)",
+        ".storybook/main.ts no longer contains a viteFinal hook",
+        ".storybook/main.ts uses rsbuildFinal with mergeRsbuildConfig from @rsbuild/core",
+        "@app and @components aliases preserved under source.alias as relative paths ('./src/...'), not absolute path.resolve(__dirname, ...) — per upstream migration guide",
+        "@storybook/addon-essentials and @storybook/addon-links remain in addons unchanged (no move to webpackAddons — these are framework-agnostic)",
+        "vite.config.ts not modified",
+        "src/Button.tsx and src/Button.stories.tsx not modified",
+        "package.json scripts.storybook and scripts.build-storybook unchanged",
+        "Post-migration `pnpm install && pnpm build-storybook` exits 0 and the build log mentions Rsbuild (not Vite)"
+      ]
+    },
+    {
+      "id": 2,
+      "eval_name": "react-webpack5-migration-svgr",
+      "fixture": "react-webpack5-migration-svgr",
+      "pre_run_baseline": {
+        "project_kind": "single-package app",
+        "ui_framework": "React 18 + TypeScript",
+        "host_builder": "no host bundler (Storybook-only)",
+        "package_manager": "pnpm",
+        "storybook_version": "8.6.x",
+        "current_storybook_framework": "@storybook/react-webpack5",
+        "storybook_devDeps": [
+          "storybook@^8.6.0",
+          "@storybook/react-webpack5@^8.6.0",
+          "@storybook/react@^8.6.0",
+          "@storybook/addon-essentials@^8.6.0",
+          "@storybook/addon-styling-webpack@^1.0.0",
+          "@svgr/webpack@^8.1.0"
+        ],
+        "key_files": [
+          ".storybook/main.ts — framework: '@storybook/react-webpack5', webpackFinal pushes a *.svg rule using @svgr/webpack as a React-component loader",
+          ".storybook/preview.ts — imports global CSS",
+          "src/Icon.tsx — imports './heart.svg' as a React component (typed via svg.d.ts)",
+          "src/Icon.stories.tsx — renders <Icon />",
+          "src/heart.svg — actual SVG asset"
+        ]
+      },
+      "prompt": "Migrate this Storybook 8 setup from @storybook/react-webpack5 to the Rsbuild builder. .storybook/main.ts uses webpackFinal to register an @svgr/webpack rule so *.svg files are imported as React components (consumed by src/Icon.tsx). The styling addon is @storybook/addon-styling-webpack. Preserve the SVG-as-React-component capability (either via @rsbuild/plugin-svgr OR by passing the existing webpack rule through tools.rspack — both are acceptable). Do not modify src/. Keep the project on Storybook 8.6.x and pick the storybook-rsbuild major that matches.",
+      "assertions": [
+        "package.json removes @storybook/react-webpack5 and @storybook/builder-webpack5 (if listed)",
+        "package.json adds storybook-react-rsbuild ^1 (matches Storybook v8) and @rsbuild/core",
+        ".storybook/main.ts framework changed to 'storybook-react-rsbuild'",
+        ".storybook/main.ts no longer contains a webpackFinal hook (replaced with rsbuildFinal OR the addon moved to webpackAddons)",
+        "SVG-as-React-component still works: either (a) @rsbuild/plugin-svgr added and registered via plugins/rsbuildFinal, OR (b) the @svgr/webpack rule passed through tools.rspack inside rsbuildFinal",
+        "@storybook/addon-styling-webpack — either kept and moved to webpackAddons (auto-translated), OR replaced with the equivalent Rsbuild-native styling setup; not silently dropped",
+        "src/Icon.tsx, src/Icon.stories.tsx, src/heart.svg unchanged",
+        "src/svg.d.ts type declaration unchanged (or, if removed, replaced with the equivalent typing for the new svgr setup)",
+        "Post-migration `pnpm install && pnpm build-storybook` exits 0",
+        "Build log shows Rsbuild active (not webpack)"
+      ]
+    },
+    {
+      "id": 3,
+      "eval_name": "vue3-vite-migration",
+      "fixture": "vue3-vite-migration",
+      "pre_run_baseline": {
+        "project_kind": "single-package app",
+        "ui_framework": "Vue 3 SFC + TypeScript",
+        "host_builder": "Vite 5 + @vitejs/plugin-vue",
+        "package_manager": "pnpm",
+        "storybook_version": "9.0.x",
+        "current_storybook_framework": "@storybook/vue3-vite",
+        "storybook_devDeps": [
+          "storybook@^9.0.0",
+          "@storybook/vue3-vite@^9.0.0",
+          "@storybook/vue3@^9.0.0",
+          "@storybook/addon-essentials@^9.0.0"
+        ],
+        "key_files": [
+          ".storybook/main.ts — framework: '@storybook/vue3-vite', no viteFinal customization",
+          ".storybook/preview.ts — minimal",
+          "src/HelloWorld.vue — single-file component (template + script setup + scoped style)",
+          "src/HelloWorld.stories.ts — CSF3 story importing the .vue component",
+          "vite.config.ts — host app uses @vitejs/plugin-vue"
+        ]
+      },
+      "prompt": "Migrate this Vue 3 + Vite project's Storybook from @storybook/vue3-vite to the Rsbuild builder. The HelloWorld.vue SFC must continue to render in the storybook build. Storybook is pinned at 9.0.x — pick the storybook-rsbuild major that matches per the upstream version-compatibility table. Do not modify vite.config.ts or src/.",
+      "assertions": [
+        "package.json removes @storybook/vue3-vite (and @storybook/builder-vite if listed)",
+        "package.json adds storybook-vue3-rsbuild ^2 (matches Storybook v9) — NOT ^1 or ^3",
+        "package.json adds @rsbuild/core (>=1.0.1)",
+        "Vue SFC support wired: @rsbuild/plugin-vue added as devDep AND registered (either via plugins[] in rsbuildFinal or via a co-located rsbuild.config.ts that storybook-builder-rsbuild picks up)",
+        ".storybook/main.ts framework changed to 'storybook-vue3-rsbuild'",
+        ".storybook/main.ts uses StorybookConfig type imported from 'storybook-vue3-rsbuild'",
+        "vite.config.ts unchanged",
+        "src/HelloWorld.vue and src/HelloWorld.stories.ts unchanged",
+        "Post-migration `pnpm install && pnpm build-storybook` exits 0 and the SFC renders (HelloWorld.stories.ts.json present in storybook-static)",
+        "Build log shows Rsbuild active"
+      ]
+    },
+    {
+      "id": 4,
+      "eval_name": "react-fresh-setup-vite-app",
+      "fixture": "react-fresh-setup-vite-app",
+      "pre_run_baseline": {
+        "project_kind": "single-package app",
+        "ui_framework": "React 18 + TypeScript",
+        "host_builder": "Vite 5",
+        "package_manager": "pnpm",
+        "storybook_present": false,
+        "key_files": [
+          "vite.config.ts — host app config",
+          "src/App.tsx + src/Button.tsx — example components",
+          "package.json — has dev=vite, build=vite build, preview=vite preview; NO storybook-related deps"
+        ]
+      },
+      "prompt": "This Vite + React 18 + TypeScript project does not have Storybook yet. Set up Storybook with the Rsbuild builder for it. Add at least one example story for the existing src/Button.tsx. Do not change vite.config.ts or any business source. The app's existing pnpm dev / pnpm build must keep working.",
+      "assertions": [
+        "package.json adds storybook (latest, ^10), storybook-react-rsbuild (^3 — matches Storybook v10), @rsbuild/core (>=1.0.1) as devDeps",
+        ".storybook/main.ts created with framework: 'storybook-react-rsbuild'",
+        ".storybook/main.ts imports StorybookConfig type from 'storybook-react-rsbuild'",
+        ".storybook/main.ts stories pattern matches src/**/*.stories.@(ts|tsx) (or equivalent that picks up the example story)",
+        ".storybook/preview.ts (or .tsx) created",
+        "package.json scripts add storybook (storybook dev) and build-storybook (storybook build)",
+        "Existing scripts.dev / scripts.build / scripts.preview unchanged",
+        "vite.config.ts unchanged",
+        "src/App.tsx and src/Button.tsx unchanged",
+        "An example src/Button.stories.tsx (or similar) created — at least one CSF3 default-export story",
+        "Post-setup `pnpm install && pnpm build-storybook` exits 0",
+        "Post-setup `pnpm build` (host app build) still exits 0"
+      ]
+    },
+    {
+      "id": 5,
+      "eval_name": "vanilla-html-fresh-setup",
+      "fixture": "vanilla-html-fresh-setup",
+      "pre_run_baseline": {
+        "project_kind": "single-package app",
+        "ui_framework": "vanilla TypeScript (no framework)",
+        "host_builder": "Vite 5",
+        "package_manager": "pnpm",
+        "storybook_present": false,
+        "key_files": [
+          "vite.config.ts — minimal Vite config",
+          "src/badge.ts — exports `createBadge(label: string): HTMLElement` (a function returning a DOM element)",
+          "src/main.ts — host app entrypoint that mounts createBadge into #app",
+          "package.json — has dev/build/preview scripts; NO storybook deps; NO react/vue/lit"
+        ]
+      },
+      "prompt": "This is a Vite + TypeScript app with no UI framework — src/badge.ts exports createBadge() that returns a raw HTMLElement. Set up Storybook with the Rsbuild builder for it. Add at least one example story for createBadge. Do not change vite.config.ts or src/badge.ts. The agent should pick the framework package that matches a vanilla-DOM project.",
+      "assertions": [
+        "package.json adds storybook-html-rsbuild (^3 — matches Storybook v10) — NOT storybook-react-rsbuild or storybook-web-components-rsbuild",
+        "package.json adds storybook (^10) and @rsbuild/core (>=1.0.1)",
+        "package.json does NOT add @rsbuild/plugin-react or @rsbuild/plugin-vue (no UI framework in project)",
+        ".storybook/main.ts created with framework: 'storybook-html-rsbuild'",
+        ".storybook/main.ts imports StorybookConfig type from 'storybook-html-rsbuild'",
+        ".storybook/main.ts stories pattern includes *.stories.ts (or equivalent that picks up the example)",
+        "package.json scripts add storybook + build-storybook entries",
+        "Existing scripts.dev / scripts.build / scripts.preview unchanged",
+        "src/badge.ts and src/main.ts unchanged",
+        "vite.config.ts unchanged",
+        "An example badge.stories.ts created — exports a default with title + at least one named story; the story render returns an HTMLElement (HTML CSF format), not JSX",
+        "Post-setup `pnpm install && pnpm build-storybook` exits 0",
+        "Post-setup `pnpm build` (host app) still exits 0"
+      ]
+    },
+    {
+      "id": 6,
+      "eval_name": "web-components-lit-fresh-setup",
+      "fixture": "web-components-lit-fresh-setup",
+      "pre_run_baseline": {
+        "project_kind": "single-package app",
+        "ui_framework": "Lit 3 (Web Components) + TypeScript",
+        "host_builder": "Vite 5",
+        "package_manager": "pnpm",
+        "storybook_present": false,
+        "key_files": [
+          "vite.config.ts — minimal Vite config",
+          "src/my-counter.ts — Lit element using @customElement('my-counter') with reactive @state count + render() returning html``",
+          "src/main.ts — host entry that registers <my-counter>",
+          "tsconfig.json — has experimentalDecorators + useDefineForClassFields false (Lit decorator requirements)",
+          "package.json — lit ^3 in deps; NO storybook deps"
+        ]
+      },
+      "prompt": "This is a Vite + Lit 3 + TypeScript Web Components project. Set up Storybook with the Rsbuild builder. Add at least one example story for src/my-counter.ts. Do not change vite.config.ts, tsconfig.json (decorator settings are intentional), or src/.",
+      "assertions": [
+        "package.json adds storybook-web-components-rsbuild (^3 — matches Storybook v10) — NOT storybook-html-rsbuild",
+        "package.json adds storybook (^10) and @rsbuild/core (>=1.0.1)",
+        "lit dep retained at ^3",
+        ".storybook/main.ts created with framework: 'storybook-web-components-rsbuild'",
+        ".storybook/main.ts imports StorybookConfig type from 'storybook-web-components-rsbuild'",
+        ".storybook/main.ts stories pattern picks up *.stories.ts",
+        "package.json scripts add storybook + build-storybook entries",
+        "src/my-counter.ts unchanged",
+        "tsconfig.json experimentalDecorators / useDefineForClassFields unchanged",
+        "vite.config.ts unchanged",
+        "An example my-counter.stories.ts created — story render returns an html`` template (lit-html), not JSX or a raw HTMLElement",
+        "Post-setup `pnpm install && pnpm build-storybook` exits 0",
+        "Post-setup `pnpm build` (host app) still exits 0"
+      ]
+    },
+    {
+      "id": 7,
+      "eval_name": "rslib-react-integration",
+      "fixture": "rslib-react-integration",
+      "pre_run_baseline": {
+        "project_kind": "single-package library",
+        "ui_framework": "React 18 + TypeScript",
+        "host_builder": "Rslib (rslib.config.ts)",
+        "package_manager": "pnpm",
+        "storybook_present": false,
+        "key_files": [
+          "rslib.config.ts — exports defineConfig with two lib outputs (esm + cjs), source.entry index, format/dts settings",
+          "src/index.ts — barrel that re-exports Button",
+          "src/Button.tsx — React component using forwardRef",
+          "package.json — @rslib/core in devDeps, react/react-dom in peerDeps; NO storybook deps; build script runs rslib build"
+        ]
+      },
+      "prompt": "This is an Rslib React component library. Set up Storybook with the Rsbuild builder so the component gallery reuses the library's Rsbuild config from rslib.config.ts (do not duplicate the build pipeline). Add at least one example story for src/Button.tsx. Do not modify rslib.config.ts or src/.",
+      "assertions": [
+        "package.json adds storybook-react-rsbuild (^3) and @rsbuild/core",
+        "package.json adds storybook-addon-rslib as devDep",
+        "package.json adds storybook (^10)",
+        ".storybook/main.ts framework: 'storybook-react-rsbuild'",
+        ".storybook/main.ts addons array includes 'storybook-addon-rslib' (string form OR object form with options)",
+        "If a configPath option is provided to storybook-addon-rslib, it points to the existing rslib.config.ts (not a duplicated config)",
+        "rslib.config.ts unchanged byte-for-byte",
+        "src/Button.tsx and src/index.ts unchanged",
+        "package.json scripts add storybook + build-storybook entries; existing build (rslib build) script unchanged",
+        "An example Button.stories.tsx created",
+        "Post-setup `pnpm install && pnpm build-storybook` exits 0",
+        "Post-setup `pnpm build` (rslib build) still exits 0 — Rslib output not broken"
+      ]
+    },
+    {
+      "id": 8,
+      "eval_name": "modernjs-app-integration",
+      "fixture": "modernjs-app-integration",
+      "pre_run_baseline": {
+        "project_kind": "single-package app",
+        "ui_framework": "React 18 + TypeScript",
+        "host_builder": "Modern.js (appTools with bundler: 'rspack')",
+        "package_manager": "pnpm",
+        "storybook_present": false,
+        "key_files": [
+          "modern.config.ts — defineConfig with appTools({ bundler: 'rspack' }), runtime.router enabled",
+          "src/routes/page.tsx — Modern.js convention-based route exporting default React component",
+          "src/components/Card.tsx — reusable React component",
+          "package.json — @modern-js/app-tools in devDeps; dev/build scripts use modern dev / modern build; NO storybook deps"
+        ]
+      },
+      "prompt": "This is a Modern.js application using appTools with the Rspack bundler. Set up Storybook with the Rsbuild builder so that Storybook reuses the Modern.js configuration via the official Modern.js integration. Add at least one example story for src/components/Card.tsx. Do not break the host app's `pnpm dev` / `pnpm build`.",
+      "assertions": [
+        "package.json adds storybook-react-rsbuild (^3), storybook-addon-modernjs, @rsbuild/core, storybook (^10)",
+        ".storybook/main.ts framework: 'storybook-react-rsbuild'",
+        ".storybook/main.ts addons array includes 'storybook-addon-modernjs'",
+        "If modern.config.ts contains a moduleFederationPlugin (it does NOT in this fixture, so this assertion is N/A), it would be gated by process.env.STORYBOOK — since absent, modern.config.ts must be byte-for-byte unchanged",
+        "modern.config.ts unchanged",
+        "src/routes/page.tsx and src/components/Card.tsx unchanged",
+        "package.json scripts add storybook + build-storybook; existing dev/build (modern dev / modern build) scripts unchanged",
+        "An example Card.stories.tsx created",
+        "Post-setup `pnpm install && pnpm build-storybook` exits 0",
+        "Post-setup `pnpm build` (modern build) still exits 0"
+      ]
+    },
+    {
+      "id": 9,
+      "eval_name": "pure-rspack-react-integration",
+      "fixture": "pure-rspack-react-integration",
+      "pre_run_baseline": {
+        "project_kind": "single-package app",
+        "ui_framework": "React 18 + TypeScript",
+        "host_builder": "Pure Rspack (rspack.config.ts) — NO @rsbuild/core in devDeps",
+        "package_manager": "pnpm",
+        "storybook_present": false,
+        "key_files": [
+          "rspack.config.ts — uses @rspack/core defineConfig with custom resolve.alias (@app), HtmlRspackPlugin, swc-loader for TSX",
+          "src/App.tsx + src/index.tsx — React app entry",
+          "package.json — @rspack/core, @rspack/cli, react, react-dom; scripts dev=rspack serve, build=rspack build; NO @rsbuild/core, NO storybook"
+        ]
+      },
+      "prompt": "This is a pure Rspack project (rspack.config.ts, no @rsbuild/core). Set up Storybook with the Rsbuild builder using the official Pure Rspack integration path: create a thin rsbuild.config.ts that merges the existing custom Rspack rules via tools.rspack so Storybook respects the project's loaders/aliases. Do not modify rspack.config.ts or src/. The host app's `pnpm dev` / `pnpm build` (which use rspack directly) must continue to work unchanged.",
+      "assertions": [
+        "package.json adds @rsbuild/core, @rsbuild/plugin-react, storybook-react-rsbuild (^3), storybook (^10) as devDeps",
+        "@rspack/core and @rspack/cli retained as devDeps (host app still uses them)",
+        "A new rsbuild.config.ts created at project root (or at a path explicitly referenced by the storybook builder rsbuildConfigPath option)",
+        "rsbuild.config.ts registers @rsbuild/plugin-react and merges the custom Rspack rules (resolve.alias @app and any custom loaders) via tools.rspack — i.e. Storybook will not lose the project's loader pipeline",
+        ".storybook/main.ts framework: 'storybook-react-rsbuild'",
+        ".storybook/main.ts imports StorybookConfig from 'storybook-react-rsbuild'",
+        "rspack.config.ts unchanged byte-for-byte",
+        "src/App.tsx and src/index.tsx unchanged",
+        "package.json scripts add storybook + build-storybook; existing dev (rspack serve) and build (rspack build) scripts unchanged",
+        "An example story file created",
+        "Post-setup `pnpm install && pnpm build-storybook` exits 0",
+        "Post-setup `pnpm build` (rspack build, NOT rsbuild) still exits 0 — host pipeline unaffected"
+      ]
+    },
+    {
+      "id": 10,
+      "eval_name": "monorepo-partial-react-webpack5-migration",
+      "fixture": "monorepo-partial-react-webpack5-migration",
+      "pre_run_baseline": {
+        "project_kind": "pnpm workspace monorepo",
+        "ui_framework": "React 18 (in ui-kit) + Node service (in api) + Next.js (in web)",
+        "package_manager": "pnpm",
+        "storybook_version": "8.6.x (only in packages/ui-kit)",
+        "current_storybook_framework": "@storybook/react-webpack5 (only in packages/ui-kit)",
+        "packages": [
+          "packages/ui-kit — React component library; HAS Storybook (@storybook/react-webpack5) with .storybook/main.ts using webpackFinal that adds resolve.alias for @ui-kit/* and registers a postcss-loader rule",
+          "packages/api — Express service in TypeScript; NO storybook",
+          "packages/web — Next.js 14 app; NO storybook",
+          "root — devDeps: typescript, eslint, prettier; NO storybook"
+        ],
+        "key_files": [
+          "pnpm-workspace.yaml — packages: ['packages/*']",
+          "packages/ui-kit/.storybook/main.ts",
+          "packages/ui-kit/package.json — includes @storybook/react-webpack5 ^8.6, storybook ^8.6, @storybook/addon-essentials, postcss, postcss-loader",
+          "packages/ui-kit/src/Button.tsx + Button.stories.tsx",
+          "packages/api/package.json + packages/api/src/server.ts",
+          "packages/web/package.json + packages/web/pages/index.tsx",
+          "root package.json"
+        ]
+      },
+      "prompt": "Migrate ONLY packages/ui-kit's Storybook from @storybook/react-webpack5 to the Rsbuild builder. The other workspace packages (packages/api, packages/web) and the root package.json must NOT be touched at all (no new deps at root, no script changes). packages/ui-kit/.storybook/main.ts has a webpackFinal hook that adds a @ui-kit/* alias and registers a postcss-loader rule. Preserve both behaviors. Storybook is on 8.6.x — pick the matching storybook-rsbuild major.",
+      "assertions": [
+        "packages/ui-kit/package.json removes @storybook/react-webpack5 and @storybook/builder-webpack5 (if listed)",
+        "packages/ui-kit/package.json adds storybook-react-rsbuild ^1 (matches Storybook v8) and @rsbuild/core",
+        "packages/ui-kit/.storybook/main.ts framework changed to 'storybook-react-rsbuild'",
+        "packages/ui-kit/.storybook/main.ts no longer contains webpackFinal (replaced with rsbuildFinal OR the postcss-loader addon migrated to webpackAddons)",
+        "@ui-kit/* alias preserved under source.alias (relative path form)",
+        "PostCSS still active in stories — either via Rsbuild's built-in postcss.config.* discovery, OR via @rsbuild/plugin-postcss / equivalent registration",
+        "packages/api/package.json byte-for-byte unchanged",
+        "packages/api/src/server.ts unchanged",
+        "packages/web/package.json byte-for-byte unchanged",
+        "packages/web/pages/index.tsx unchanged",
+        "Root package.json byte-for-byte unchanged (no storybook-* or @rsbuild/* added at root)",
+        "pnpm-workspace.yaml unchanged",
+        "packages/ui-kit/src/Button.tsx and Button.stories.tsx unchanged",
+        "Post-migration `pnpm -C packages/ui-kit install && pnpm -C packages/ui-kit build-storybook` exits 0",
+        "Post-migration root-level commands targeting api/web (e.g. pnpm -C packages/api build, pnpm -C packages/web build) still exit 0 — unaffected scopes"
+      ]
+    }
+  ]
+}

--- a/skills-test/storybook-rsbuild/report.md
+++ b/skills-test/storybook-rsbuild/report.md
@@ -1,0 +1,127 @@
+# storybook-rsbuild — evaluation report
+
+**Date:** 2026-05-06
+**Model:** Sonnet 4.6 (`claude-sonnet-4-6`) — runner agents and grader subagents
+**Skill version:** `skills/storybook-rsbuild/SKILL.md` at `chore/rstest-best-practices-eval` HEAD
+
+## Setup
+
+- **Fixtures** (10, under `/tmp/agent-skills-evals/storybook-rsbuild/fixtures`, ~1.6 GB total with `node_modules` pre-installed):
+  - `react-vite-migration` — Storybook 8.6 + `@storybook/react-vite` + `viteFinal` adding `@app`/`@components` aliases via `path.resolve(__dirname, ...)`
+  - `react-webpack5-migration-svgr` — Storybook 8.6 + `@storybook/react-webpack5` + `webpackFinal` registering `@svgr/webpack` rule + `@storybook/addon-styling-webpack`
+  - `vue3-vite-migration` — Storybook 9.0 + `@storybook/vue3-vite` + `HelloWorld.vue` SFC (version-table test: must pick `^2`, not `^1`/`^3`)
+  - `react-fresh-setup-vite-app` — Vite + React app with no Storybook
+  - `vanilla-html-fresh-setup` — Vite + plain TS app, `createBadge()` returns HTMLElement (must pick `storybook-html-rsbuild`)
+  - `web-components-lit-fresh-setup` — Vite + Lit 3 (must pick `storybook-web-components-rsbuild`)
+  - `rslib-react-integration` — Rslib React component library; agent must use `storybook-addon-rslib` overlay, not duplicate the build pipeline
+  - `modernjs-app-integration` — Modern.js app with `appTools({ bundler: 'rspack' })`; agent must use `storybook-addon-modernjs`
+  - `pure-rspack-react-integration` — Pure Rspack project (no `@rsbuild/core`); agent must create a thin `rsbuild.config.ts` merging existing rules via `tools.rspack`
+  - `monorepo-partial-react-webpack5-migration` — pnpm workspace; migrate ONLY `packages/ui-kit`, leave root + `packages/api` (Express) + `packages/web` (Next.js 14) byte-for-byte untouched
+- **Grader**: 118 assertions across the 10 fixtures — mix of structural checks (configs, devDeps, scripts) + filesystem byte-for-byte diffs against the original fixture + post-task build-output existence checks (`storybook-static/`, `dist/`).
+- **Design**: 10 parallel `with_skill` subagents, 1 sample per cell. Each agent worked on its own APFS-cloned fixture copy under `runs/run-6/with_skill/<eval_name>/`. 10 parallel grader subagents post-hoc.
+
+## Results
+
+```plaintext
++---------------------------------------------------+--------------+----------+----------+
+|  Eval                                             |  Pass/Total  |  Tokens  |  Time    |
++---------------------------------------------------+--------------+----------+----------+
+|  1  react-vite-migration                          |  11/12       |  28.9k   |   174s   |
+|  2  react-webpack5-migration-svgr                 |  10/10       |  34.3k   |   247s   |
+|  3  vue3-vite-migration                           |  10/10       |  38.3k   |   444s   |
+|  4  react-fresh-setup-vite-app                    |  12/12       |  22.1k   |   106s   |
+|  5  vanilla-html-fresh-setup                      |  13/13       |  21.4k   |   131s   |
+|  6  web-components-lit-fresh-setup                |  13/13       |  25.7k   |   135s   |
+|  7  rslib-react-integration                       |  12/12       |  24.4k   |   135s   |
+|  8  modernjs-app-integration                      |   8/9        |  42.4k   |   266s   |
+|  9  pure-rspack-react-integration                 |  11/12       |  27.4k   |   222s   |
+|  10 monorepo-partial-react-webpack5-migration     |  14/15       |  29.7k   |   211s   |
++---------------------------------------------------+--------------+----------+----------+
+|  Total                                            |  114/118     |  29.5k   |   207s   |
+|                                                   |  96.6%       |  (mean)  |  (mean)  |
++---------------------------------------------------+--------------+----------+----------+
+```
+
+Four failing assertions across three buckets:
+
+- **Eval 1, Eval 10 — alias form regression to `path.resolve(__dirname, ...)`** in the `viteFinal` / `webpackFinal` → `rsbuildFinal` port. The migration guide's "Use relative paths in `resolve.alias`" tip in upstream docs does not always override the agent's "preserve original code verbatim" prior. This is the cost of keeping the skill as a pure router (it doesn't duplicate the SSOT tip).
+- **Eval 8 — Modern.js `dist/` clobber** caused by a real upstream bug in `storybook-addon-modernjs`; fixed in this branch, awaiting release. See [Eval 8 root cause](#eval-8--modernjs-dist-clobber-upstream-bug) below.
+- **Eval 9 — `storybook-react-rsbuild ^2` instead of `^3`** under the pure Rspack integration. The agent observed peer-version uncertainty between `@rsbuild/core@^2` (required by `storybook-rsbuild@^3`) and the host app's `@rspack/core@^1`, and conservatively downgraded. N=1 noise on a peer-resolution decision; the same eval has installed `^3` cleanly in adjacent runs of this skill.
+
+## Skill / rubric changes captured in this report
+
+- **Skill (`SKILL.md`, Principles + Migration Step 7)** — Phase B cleanup is framed as imperative obligation, not passive permission. Migration is one task with two ordered phases: install + reconfigure, then *in the same task* delete the old framework package, the old builder package, and the legacy `webpackFinal` / `viteFinal` block.
+- **Skill (`SKILL.md`, Principle 2)** — version pins must come from each framework guide's Requirements table; the skill no longer mentions sandboxes / examples as a referent at all (positive instruction only).
+- **Skill (`SKILL.md`)** — the trailing `## Examples` link to upstream sandboxes was removed. The skill depends on documentation (SSOT), not on examples.
+- **Rubric (`evals/evals.json`, eval 4)** — removed the `@rsbuild/plugin-react` direct-devDep assertion. The framework guide install command does not include it, and `@rsbuild/plugin-react` is a transitive dep of `storybook-react-rsbuild`. The assertion was over-strict for a Vite-host fresh setup; only the pure Rspack integration (eval 9) requires it explicitly because that path constructs a custom `rsbuild.config.ts`.
+
+## Did the skill changes work?
+
+**Phase B cleanup — yes, consistently.** Migration evals (1, 2, 3, 10) all complete cleanup in the same task: old framework package, old builder package, and legacy hooks are removed after Verification passes; `pnpm install` re-runs to refresh the lockfile. Agent reports include explicit "Phase B" sections describing the cleanup work.
+
+**Alias form — accepted regression.** Two evals (1, 10) ported the `viteFinal` / `webpackFinal` aliases verbatim with `path.resolve(__dirname, ...)`. The migration guide carries a `:::tip Use relative paths in resolve.alias` block, but the SSOT tip on its own is not enough to overcome the agent's "preserve original code" prior. The skill could mirror the tip with an explicit rewrite directive — that delivered 100% canonical form in an earlier run — but that mirroring violates the skill's role as a pure router. The skill stays clean; the cost is the −2 points seen here.
+
+## Eval 8 — Modern.js dist/ clobber: upstream bug
+
+### Reproduction
+
+Reset eval 8 fixture, ran `pnpm build` then `pnpm build-storybook` in sequence:
+
+```
+$ pnpm build
+  → dist/ contains: html/, modern.config.json, route.json, static/  ✅ correct
+
+$ pnpm build-storybook
+  → "Output directory: storybook-static" (banner)
+  → dist/ contents: iframe.html, mocker-runtime-injected.js, static/js/*.iframe.bundle.js
+  → storybook-static/ contents: manager assets only (no iframe.html)
+```
+
+Storybook reports it built to `storybook-static/`, but the **preview build** physically writes to `dist/`, clobbering the Modern.js host build. Storybook's manager (in `storybook-static/`) then can't find its iframe at the relative path it expects — Storybook itself is broken in addition to Modern.js. The bug reproduces deterministically with the canonical setup the integration guide currently shows.
+
+### Root cause
+
+`storybook-addon-modernjs` reuses the Modern.js Rsbuild config wholesale, including `output.distPath.root = 'dist'` (which `appTools` sets implicitly). When Storybook's preview build inherits this Rsbuild config via the addon, the preview output goes to `dist/` instead of `storybook-static/`. The manager build uses Storybook's defaults independently, so the two halves get separated.
+
+This is **not a skill issue** and **not an agent error**.
+
+### Fix: upstream, not SSOT
+
+Initial instinct was to amend `integrations/modernjs.mdx` with a `rsbuildFinal` workaround block. That's wrong: it bakes a workaround for an upstream bug into the documented "right way to do it", creates copy-paste maintenance burden for every user, and obscures the real defect. The fix belongs in the `storybook-addon-modernjs` package itself — users following the canonical setup should get correct behavior without ceremony.
+
+**Bug location:** `packages/addon-modernjs/src/preset.ts`, before the final `mergeRsbuildConfig`.
+
+**Fix applied:** strip output fields that Storybook's preview iframe owns (`distPath`, `assetPrefix`, `cleanDistPath`, `filename`) from the Modern.js-derived Rsbuild config before merging. `builder-rsbuild` hardcodes these as defensive defaults in `iframe-rsbuild.config.ts`, but that merge runs *before* the `rsbuildFinal` hook, so any value Modern.js produced silently overrides them.
+
+**Verified end-to-end** by rebuilding the addon, swapping the patched `dist/preset.js` into the eval fixture's `node_modules/.pnpm/.../storybook-addon-modernjs/dist/`, removing all manual workarounds from `.storybook/main.ts`, and running `pnpm build && pnpm build-storybook` in sequence:
+
+```
+dist/             ← Modern.js: html/, modern.config.json, route.json, static/  ✅
+storybook-static/ ← Storybook: iframe.html, project.json, static/              ✅
+```
+
+Both builds coexist correctly with the canonical (workaround-free) `.storybook/main.ts`.
+
+### Status
+
+The fix lands in `packages/addon-modernjs/src/preset.ts` plus a regression test at `e2e/tests/modernjs-react.spec.ts` (asserts a sentinel file in `dist/` survives a Storybook build). Until the next `storybook-addon-modernjs` release ships to npm, an unmodified fixture would still see the bug — eval 8 stays at 8/9 in this report. After the release lands, eval 8 should hit 9/9 and the headline ceiling rises by one point. (See PR description for release coordination.)
+
+## Architecture validation
+
+The skill is structured as **action router + behavioral checklist**. All factual mappings — version table, package names, install commands, config conversion patterns including the relative-alias tip — live upstream at `storybook.rsbuild.rs`. The skill does not duplicate the docs; it tells agents *which page to fetch* and *what behavioral SOPs to follow* (Phase B cleanup, scope discipline, addon preservation).
+
+The 96.6% pass rate is the steady state of that partitioning. Of the 4 failing assertions:
+
+- **1 fail** is an unrelated upstream bug (eval 8) — fixed in this branch.
+- **2 fails** are alias-form regressions (evals 1, 10) — sticky training prior the SSOT tip alone doesn't override. Mirroring the tip in the skill closes them; doing so duplicates SSOT and is not the right shape.
+- **1 fail** is N=1 sample noise on peer-version conservatism (eval 9).
+
+None are in the skill's domain to fix without crossing the duplication line.
+
+## Artifacts
+
+- Run output trees: `/tmp/agent-skills-evals/storybook-rsbuild/runs/run-6/with_skill/<eval_name>/`
+- Aggregate: `/tmp/agent-skills-evals/storybook-rsbuild/grades/aggregate-run-6.json`
+- Skill: `skills/storybook-rsbuild/SKILL.md`
+- Rubric: `skills-test/storybook-rsbuild/evals/evals.json`
+- Upstream fix: `packages/addon-modernjs/src/preset.ts` + `e2e/tests/modernjs-react.spec.ts` (in storybook-rsbuild repo, this branch)

--- a/skills-test/storybook-rsbuild/report.md
+++ b/skills-test/storybook-rsbuild/report.md
@@ -50,7 +50,7 @@ Four failing assertions across three buckets:
 
 ## Skill / rubric changes captured in this report
 
-- **Skill (`SKILL.md`, Principles + Migration Step 7)** — Phase B cleanup is framed as imperative obligation, not passive permission. Migration is one task with two ordered phases: install + reconfigure, then *in the same task* delete the old framework package, the old builder package, and the legacy `webpackFinal` / `viteFinal` block.
+- **Skill (`SKILL.md`, Principles + Migration Step 7)** — Phase B cleanup is framed as imperative obligation, not passive permission. Migration is one task with two ordered phases: install + reconfigure, then _in the same task_ delete the old framework package, the old builder package, and the legacy `webpackFinal` / `viteFinal` block.
 - **Skill (`SKILL.md`, Principle 2)** — version pins must come from each framework guide's Requirements table; the skill no longer mentions sandboxes / examples as a referent at all (positive instruction only).
 - **Skill (`SKILL.md`)** — the trailing `## Examples` link to upstream sandboxes was removed. The skill depends on documentation (SSOT), not on examples.
 - **Rubric (`evals/evals.json`, eval 4)** — removed the `@rsbuild/plugin-react` direct-devDep assertion. The framework guide install command does not include it, and `@rsbuild/plugin-react` is a transitive dep of `storybook-react-rsbuild`. The assertion was over-strict for a Vite-host fresh setup; only the pure Rspack integration (eval 9) requires it explicitly because that path constructs a custom `rsbuild.config.ts`.
@@ -91,7 +91,7 @@ Initial instinct was to amend `integrations/modernjs.mdx` with a `rsbuildFinal` 
 
 **Bug location:** `packages/addon-modernjs/src/preset.ts`, before the final `mergeRsbuildConfig`.
 
-**Fix applied:** strip output fields that Storybook's preview iframe owns (`distPath`, `assetPrefix`, `cleanDistPath`, `filename`) from the Modern.js-derived Rsbuild config before merging. `builder-rsbuild` hardcodes these as defensive defaults in `iframe-rsbuild.config.ts`, but that merge runs *before* the `rsbuildFinal` hook, so any value Modern.js produced silently overrides them.
+**Fix applied:** strip output fields that Storybook's preview iframe owns (`distPath`, `assetPrefix`, `cleanDistPath`, `filename`) from the Modern.js-derived Rsbuild config before merging. `builder-rsbuild` hardcodes these as defensive defaults in `iframe-rsbuild.config.ts`, but that merge runs _before_ the `rsbuildFinal` hook, so any value Modern.js produced silently overrides them.
 
 **Verified end-to-end** by rebuilding the addon, swapping the patched `dist/preset.js` into the eval fixture's `node_modules/.pnpm/.../storybook-addon-modernjs/dist/`, removing all manual workarounds from `.storybook/main.ts`, and running `pnpm build && pnpm build-storybook` in sequence:
 
@@ -108,7 +108,7 @@ The fix lands in `packages/addon-modernjs/src/preset.ts` plus a regression test 
 
 ## Architecture validation
 
-The skill is structured as **action router + behavioral checklist**. All factual mappings — version table, package names, install commands, config conversion patterns including the relative-alias tip — live upstream at `storybook.rsbuild.rs`. The skill does not duplicate the docs; it tells agents *which page to fetch* and *what behavioral SOPs to follow* (Phase B cleanup, scope discipline, addon preservation).
+The skill is structured as **action router + behavioral checklist**. All factual mappings — version table, package names, install commands, config conversion patterns including the relative-alias tip — live upstream at `storybook.rsbuild.rs`. The skill does not duplicate the docs; it tells agents _which page to fetch_ and _what behavioral SOPs to follow_ (Phase B cleanup, scope discipline, addon preservation).
 
 The 96.6% pass rate is the steady state of that partitioning. Of the 4 failing assertions:
 

--- a/skills/storybook-rsbuild/SKILL.md
+++ b/skills/storybook-rsbuild/SKILL.md
@@ -6,6 +6,24 @@ compatibility: Requires network access to read upstream docs at storybook.rsbuil
 
 # Storybook Rsbuild
 
+## Goal
+
+Set up Storybook on Rsbuild, or migrate an existing Storybook to it. Factual mappings — version compatibility, package names, install commands, config conversion patterns — live in upstream docs at `storybook.rsbuild.rs`. This skill is an action router and a behavioral checklist; it does not duplicate the docs.
+
+## Principles (must follow)
+
+1. **Single source of truth is upstream.** Fetch the relevant `storybook.rsbuild.rs` page for version tables, install commands, and config conversion patterns. Do not infer version pins or package names from training memory — the ecosystem moves faster than the model's prior.
+
+2. **Pin from the framework guide's Requirements table.** Each framework guide page (e.g. `https://storybook.rsbuild.rs/guide/framework/react`) carries a Requirements section listing the canonical compatible version ranges — that is the authoritative source for version pins. For fresh setups, install the latest stable `storybook` major and the matching `storybook-rsbuild` major. Do not pin from version numbers you see in code snippets elsewhere; only the docs are authoritative.
+
+3. **Declare `@rsbuild/core` directly.** `storybook-<framework>-rsbuild` lists `@rsbuild/core` as a peer dependency, but you must still add `@rsbuild/core` to the project's own `devDependencies` so version pins and lockfile audits remain unambiguous and a future framework-package release that drops the peer cannot silently break the build.
+
+4. **Migration is one task with two ordered phases — both required.** Phase A: install the new framework package and update config; leave the old framework package, old builder package, and old `webpackFinal` / `viteFinal` blocks in place so [Verification](#verification) has a rollback path. Phase B: as soon as Verification passes, in the same task, remove the old framework package (e.g. `@storybook/react-webpack5`, `@storybook/vue3-vite`), the old builder package (e.g. `@storybook/builder-webpack5`, `@storybook/builder-vite`), and the old `webpackFinal` / `viteFinal` block. A migration that ends with both builders' framework packages still in `package.json` is incomplete — leaving them is the most common silent regression in this skill's evals. Phase A on its own is not a valid stopping point; if you ran Verification, you must also run cleanup.
+
+5. **Preserve addons; never silently drop.** When migrating, webpack-only addons (e.g. `@storybook/addon-styling-webpack`) must either be passed through `webpackAddons` (so upstream auto-translation handles them) or replaced with the equivalent Rsbuild-native pipeline (`@rsbuild/plugin-postcss`, `tools.postcss`, etc.). A migration that removes a styling addon and produces a passing `storybook build` but a visually broken story tree is still a regression.
+
+6. **Operate in scope.** In monorepos, modify only the package that hosts stories. Do not edit business source files unless the migration strictly requires it.
+
 ## Step 1 — Detect scenario
 
 Read `package.json` and project structure to determine existing Storybook state:
@@ -47,10 +65,12 @@ Infer the UI framework from app dependencies (`react`, `vue`, `lit`, etc.):
 ### 3. Set up Storybook
 
 1. In monorepos, operate in the package that will host stories
-2. Read and follow the framework guide matched above
-3. Ensure `.storybook/main.*` uses the correct `framework: '<storybook-*-rsbuild>'`
-4. Ensure `package.json` has `storybook dev` and `storybook build` scripts
-5. Run [Verification](#verification) below
+2. Read and follow the framework guide matched above; install the **latest stable** `storybook` major and the matching `storybook-<framework>-rsbuild` major (Principle 2)
+3. Add `@rsbuild/core` to `devDependencies` directly, alongside `storybook-<framework>-rsbuild` (Principle 3)
+4. Ensure `.storybook/main.*` uses the correct `framework: '<storybook-*-rsbuild>'`
+5. Ensure `package.json` has `storybook dev` and `storybook build` scripts
+6. If no story file exists yet, scaffold at least one minimal example story (e.g. `src/stories/Example.stories.*`) so [Verification](#verification) step 2 has something to render
+7. Run [Verification](#verification) below
 
 ## Migration Workflow
 
@@ -60,11 +80,16 @@ Follow these steps **in order**:
 
 1. **Detect migration type** — read `.storybook/main.*` (`framework` field and/or `core.builder`) and `package.json` dependencies to classify as "from webpack5" or "from Vite", then select the matching section in the migration guide
 2. **Resolve version compatibility** — read the "Version compatibility" section in the migration guide, select the correct `storybook-rsbuild` major based on installed Storybook version
-3. **Replace packages** — apply the install/remove mapping from the migration guide using the project's package manager (detect from lockfile); only change packages required by the migration
+3. **Replace packages** — apply the install/remove mapping from the migration guide using the project's package manager (detect from lockfile); only change packages required by the migration. Always add `@rsbuild/core` as a direct devDep alongside the new framework package (Principle 3). Do not remove the old framework package or old devDeps yet — that happens after Verification (Principle 4)
 4. **Update `.storybook/main.*`** — apply the config changes exactly as shown in the migration guide for the detected framework
 5. **Migrate custom builder hooks** — search for legacy builder hooks (`webpackFinal` / `viteFinal`); if found, convert following the upstream configuration guide (https://storybook.rsbuild.rs/guide/configuration)
-6. **Handle addon compatibility** — keep addons unchanged initially; if build errors indicate addon incompatibility, consult the migration guide's addon section and apply the recommended fix
-7. **Verify** — confirm the migration is complete, then run [Verification](#verification) below
+6. **Handle addon compatibility** — keep addons unchanged initially. If a webpack-only addon must change, route it through `webpackAddons` for upstream auto-translation, or replace it with the Rsbuild-native equivalent — never silently drop it (Principle 5). Consult the migration guide's addon section for the recommended fix
+7. **Verify, then clean up — both required** — run [Verification](#verification) below; once it passes, in the same task complete all of the following before reporting done (Principle 4):
+   - Remove the old framework package from `package.json` devDependencies (e.g. `@storybook/react-webpack5`, `@storybook/vue3-webpack5`, `@storybook/react-vite`, `@storybook/vue3-vite`, `@storybook/html-webpack5`, `@storybook/web-components-webpack5`, etc.)
+   - Remove the old builder package if separately listed (e.g. `@storybook/builder-webpack5`, `@storybook/builder-vite`)
+   - Delete the legacy `webpackFinal` / `viteFinal` block from `.storybook/main.*`
+   - Drop any old-builder-only devDeps that no longer have consumers
+   - Re-run `pnpm install` (or the project's package manager equivalent) so the lockfile reflects the cleanup
 
 If a factual mapping is needed (version table, package names, conversion patterns) and not present in this skill, fetch it from the upstream docs — do not guess.
 
@@ -73,7 +98,7 @@ If a factual mapping is needed (version table, package names, conversion pattern
 ## Verification
 
 1. `storybook dev` starts without errors
-2. Stories render correctly
+2. At least one story renders correctly in the browser (a clean dev-server boot is not sufficient — a missing-glob in `stories` or a broken framework wiring will only surface here)
 3. HMR works
 4. `storybook build` completes
 5. Check startup logs to confirm the Rsbuild builder is active (not webpack/vite)
@@ -93,7 +118,3 @@ If a factual mapping is needed (version table, package names, conversion pattern
 ## Configuration
 
 For `rsbuildFinal`, builder options, TypeScript, and framework-specific options → read https://storybook.rsbuild.rs/guide/configuration
-
-## Examples
-
-For working sandboxes → https://storybook.rsbuild.rs/guide/examples


### PR DESCRIPTION
## Summary

Add a 10-fixture eval suite for the `storybook-rsbuild` skill. Final result: **114 / 118 (96.6%) with_skill**.

Skill updates from findings: Phase A/B migration cleanup as imperative (not passive); pin versions from each framework guide's Requirements table; drop the `## Examples` link to keep the skill a pure documentation router.

## Remaining failures

- **Evals 1, 10** — alias-form regression. Mirroring the SSOT tip closes the gap but duplicates docs; accepted −2 pts to keep skill pure-router.
- **Eval 8** — upstream `storybook-addon-modernjs` `dist/` clobber. Fix landed in that repo (this branch) but pending release; eval rises to 9/9 once published.
- **Eval 9** — N=1 peer-version conservatism. Adjacent runs install correctly.