### PR TITLE
feat: add CodSpeed regression analysis skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,14 @@ npx skills add rstackjs/agent-skills --skill rspack-split-chunks
 
 Diagnose and optimize Rspack `optimization.splitChunks` configuration. Use when tuning production chunking, reducing duplicated modules, improving cache behavior, or debugging over-fetch caused by `name` and `cacheGroups`.
 
+### codspeed-regression-analysis
+
+```bash
+npx skills add rstackjs/agent-skills --skill codspeed-regression-analysis
+```
+
+Analyze CodSpeed performance regressions from GitHub Actions artifacts and Callgrind outputs. Use when comparing a PR against a valid baseline, explaining accesses and estimated_cycles deltas, separating I-cache vs D-cache regressions, or producing an evidence-based root-cause report for a CodSpeed slowdown.
+
 ## Rsbuild Skills
 
 ### rsbuild-best-practices

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -1,6 +1,9 @@
 # Custom Dictionary Words
 bundleless
 Bytedance
+callgrind
+Callgrind
+codspeed
 condvar
 coredump
 corepack
@@ -26,6 +29,7 @@ prebundle
 preprocessors
 psynch
 pthread
+hotspots
 rgba
 rsbuild
 rsdoctor

--- a/skills/codspeed-regression-analysis/SKILL.md
+++ b/skills/codspeed-regression-analysis/SKILL.md
@@ -9,61 +9,48 @@ Prefer direct artifact evidence over intuition. Keep the analysis read-only unle
 
 ## Core Workflow
 
-1. Identify the exact comparison target.
-   - Prefer the PR head run and its true baseline run from the same branch ancestry.
-   - Verify the merge base before treating a `main` run as comparable.
-   - Reject comparisons across different benchmark definitions, different targets, or different CodSpeed modes unless the report clearly labels them as non-comparable.
-2. Verify measurement parity before interpreting deltas.
-   - Confirm benchmark list and ordering from `runner.log`.
-   - Confirm `codspeed` version, `cargo-codspeed` version, target triple, simulation mode, and important env vars such as `RAYON_NUM_THREADS`.
-   - Treat missing parity as a blocker, not a footnote.
-3. Download and inspect the raw profiling artifact.
-   - Prefer the uploaded `codspeed-valgrind-tmp-*` artifact from the benchmark run.
-   - Read `MANIFEST.txt`, `runner.log`, and the large merged Callgrind file referenced by the measured benchmark process.
-   - Ignore tiny helper-process outputs except when they explain setup overhead or tool noise.
-4. Extract per-benchmark totals before looking at individual functions.
-   - Parse each `part:` block and its `desc: Trigger:` label from the merged Callgrind file.
-   - Use the `totals:` line for each measured benchmark as the source of truth.
-   - Compute `accesses` and `estimated_cycles` from the formulas in [references/codspeed-metrics.md](references/codspeed-metrics.md).
-5. Classify the regression shape.
-   - If most benchmarks move together in the same direction, suspect environment drift, benchmark definition drift, or a broad runtime/toolchain effect.
-   - If only a few benchmarks move, focus on those specific stages or cases.
-   - If `estimated_cycles` rises much more than `accesses`, inspect cache-miss growth before assuming algorithmic work increased.
-6. Separate instruction-cache and data-cache effects.
+1. Pick a valid baseline.
+   - Prefer the PR head run and its true merge-base baseline.
+   - Verify merge base, benchmark target, CodSpeed mode, and benchmark list before comparing numbers.
+   - Stop and mark the comparison invalid if parity is missing.
+2. Read the raw artifact, not only the GitHub check summary.
+   - Prefer `codspeed-valgrind-tmp-*`.
+   - Inspect `MANIFEST.txt`, `runner.log`, and the merged Callgrind output for the measured benchmark process.
+3. Extract per-benchmark totals first.
+   - Parse each `part:` and `desc: Trigger:` block.
+   - Use `totals:` as the source of truth.
+   - Compute `accesses` and `estimated_cycles` with [references/codspeed-metrics.md](references/codspeed-metrics.md).
+4. Classify the shape before chasing hotspots.
+   - Broad movement across many benchmarks suggests environment, benchmark, or toolchain drift.
+   - A few moved benchmarks suggest a localized regression.
+   - If cycles rise much more than accesses, inspect cache misses before assuming more work was done.
+5. Split cache effects before assigning blame.
    - Break L1 growth into `I1mr`, `D1mr`, and `D1mw`.
-   - If `I1mr` dominates, suspect binary layout or instruction-path expansion before blaming data-structure growth.
-   - If `D1mr`/`D1mw` dominate, inspect structure sizes, allocation patterns, hash-table churn, traversal order, and data locality.
-   - Use the heuristics in [references/codspeed-metrics.md](references/codspeed-metrics.md) instead of hand-waving about “cache regressions”.
-7. Compare hotspots only after totals establish the shape.
-   - Run `callgrind_annotate` on the extracted benchmark part, sorted by the event that actually regressed.
-   - For instruction-cache regressions, sort or inspect `I1mr` first.
-   - For data-cache regressions, inspect `D1mr`, `D1mw`, and `DLmr` first.
-   - Prefer functions that account for a meaningful share of the changed event, not just the largest absolute hotspot.
-8. Distinguish direct execution from indirect side effects.
-   - Search the extracted profile for the files and symbols changed by the PR.
-   - If the new code is not on the hot path but old hotspots worsen, explain why this can still happen:
-     binary layout changes, codegen differences, metadata size growth, changed inlining, or changed allocation/layout of shared structures.
-   - Do not claim “the changed code is responsible” without either hot-path execution evidence or a coherent indirect mechanism.
-9. Check for shared-structure expansion.
-   - If the PR adds fields to widely carried structs or cached metadata, quantify the layout change directly.
-   - Report the measured size delta when it is relevant to `D1` growth.
-   - Treat shared-structure growth as secondary evidence for data-cache regressions, not instruction-cache regressions.
-10. Produce a root-cause report in this order.
-
-- State whether the comparison is valid.
-- State whether the regression is broad or localized.
-- List the largest affected benchmarks with before/after values and percentages.
-- Explain whether the main driver is accesses, I1 misses, D1 misses, or LL misses.
-- Identify the most likely root cause and clearly mark it as direct or indirect.
-- List excluded explanations such as baseline mismatch, benchmark mismatch, or tool mismatch.
+   - `I1mr`-heavy regressions usually point to binary layout, code-size, or instruction-path changes.
+   - `D1`-heavy regressions usually point to structure growth, allocation churn, or locality loss.
+6. Inspect hotspots only for the regressed event.
+   - Use `callgrind_annotate` on the extracted benchmark part.
+   - Sort by `I1mr` for instruction-cache regressions and by `D1mr`/`D1mw` for data-cache regressions.
+   - Prefer functions that explain a meaningful share of the changed event.
+7. Distinguish direct and indirect regressions.
+   - Search the extracted profile for changed files and symbols.
+   - If the new code is not on the hot path but old hotspots worsen, explain the indirect mechanism instead of implying direct causality.
+   - If the PR grew a widely carried struct or metadata object, quantify the size delta and use it only as evidence for data-cache regressions.
+8. Report in this order.
+   - Whether the comparison is valid
+   - Whether the movement is broad or localized
+   - The most affected benchmarks with before/after values
+   - The main driver: accesses, `I1mr`, `D1mr`/`D1mw`, or LL misses
+   - The most likely root cause, labeled direct or indirect
+   - Excluded explanations such as baseline mismatch or benchmark mismatch
 
 ## Reporting Rules
 
 - Quote exact run IDs, artifact names, SHAs, and benchmark names when available.
 - Prefer percentages and absolute counts together.
-- When a result is only a likely explanation, say so explicitly.
-- When a benchmark does not execute the changed code directly, say that explicitly instead of implying causal certainty.
-- Avoid calling a small and noisy change a “regression” if the total movement is near zero and the evidence is weak.
+- Mark inferences as inferences.
+- If the benchmark does not execute the changed code directly, say so explicitly.
+- Do not call tiny, noisy movement a real regression without stronger evidence.
 
 ## Useful Commands
 

--- a/skills/codspeed-regression-analysis/SKILL.md
+++ b/skills/codspeed-regression-analysis/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: codspeed-regression-analysis
+description: Use when analyzing CodSpeed performance regressions from GitHub Actions artifacts, Callgrind outputs, or CodSpeed check results. Helps compare a PR against a valid baseline, extract accesses and estimated_cycles, separate instruction-cache vs data-cache regressions, identify whether a slowdown comes from changed business logic or binary/data-layout side effects, and produce an evidence-based root-cause report.
+---
+
+# CodSpeed Regression Analysis
+
+Prefer direct artifact evidence over intuition. Keep the analysis read-only unless the user explicitly asks for code changes.
+
+## Core Workflow
+
+1. Identify the exact comparison target.
+   - Prefer the PR head run and its true baseline run from the same branch ancestry.
+   - Verify the merge base before treating a `main` run as comparable.
+   - Reject comparisons across different benchmark definitions, different targets, or different CodSpeed modes unless the report clearly labels them as non-comparable.
+2. Verify measurement parity before interpreting deltas.
+   - Confirm benchmark list and ordering from `runner.log`.
+   - Confirm `codspeed` version, `cargo-codspeed` version, target triple, simulation mode, and important env vars such as `RAYON_NUM_THREADS`.
+   - Treat missing parity as a blocker, not a footnote.
+3. Download and inspect the raw profiling artifact.
+   - Prefer the uploaded `codspeed-valgrind-tmp-*` artifact from the benchmark run.
+   - Read `MANIFEST.txt`, `runner.log`, and the large merged Callgrind file referenced by the measured benchmark process.
+   - Ignore tiny helper-process outputs except when they explain setup overhead or tool noise.
+4. Extract per-benchmark totals before looking at individual functions.
+   - Parse each `part:` block and its `desc: Trigger:` label from the merged Callgrind file.
+   - Use the `totals:` line for each measured benchmark as the source of truth.
+   - Compute `accesses` and `estimated_cycles` from the formulas in [references/codspeed-metrics.md](references/codspeed-metrics.md).
+5. Classify the regression shape.
+   - If most benchmarks move together in the same direction, suspect environment drift, benchmark definition drift, or a broad runtime/toolchain effect.
+   - If only a few benchmarks move, focus on those specific stages or cases.
+   - If `estimated_cycles` rises much more than `accesses`, inspect cache-miss growth before assuming algorithmic work increased.
+6. Separate instruction-cache and data-cache effects.
+   - Break L1 growth into `I1mr`, `D1mr`, and `D1mw`.
+   - If `I1mr` dominates, suspect binary layout or instruction-path expansion before blaming data-structure growth.
+   - If `D1mr`/`D1mw` dominate, inspect structure sizes, allocation patterns, hash-table churn, traversal order, and data locality.
+   - Use the heuristics in [references/codspeed-metrics.md](references/codspeed-metrics.md) instead of hand-waving about “cache regressions”.
+7. Compare hotspots only after totals establish the shape.
+   - Run `callgrind_annotate` on the extracted benchmark part, sorted by the event that actually regressed.
+   - For instruction-cache regressions, sort or inspect `I1mr` first.
+   - For data-cache regressions, inspect `D1mr`, `D1mw`, and `DLmr` first.
+   - Prefer functions that account for a meaningful share of the changed event, not just the largest absolute hotspot.
+8. Distinguish direct execution from indirect side effects.
+   - Search the extracted profile for the files and symbols changed by the PR.
+   - If the new code is not on the hot path but old hotspots worsen, explain why this can still happen:
+     binary layout changes, codegen differences, metadata size growth, changed inlining, or changed allocation/layout of shared structures.
+   - Do not claim “the changed code is responsible” without either hot-path execution evidence or a coherent indirect mechanism.
+9. Check for shared-structure expansion.
+   - If the PR adds fields to widely carried structs or cached metadata, quantify the layout change directly.
+   - Report the measured size delta when it is relevant to `D1` growth.
+   - Treat shared-structure growth as secondary evidence for data-cache regressions, not instruction-cache regressions.
+10. Produce a root-cause report in this order.
+
+- State whether the comparison is valid.
+- State whether the regression is broad or localized.
+- List the largest affected benchmarks with before/after values and percentages.
+- Explain whether the main driver is accesses, I1 misses, D1 misses, or LL misses.
+- Identify the most likely root cause and clearly mark it as direct or indirect.
+- List excluded explanations such as baseline mismatch, benchmark mismatch, or tool mismatch.
+
+## Reporting Rules
+
+- Quote exact run IDs, artifact names, SHAs, and benchmark names when available.
+- Prefer percentages and absolute counts together.
+- When a result is only a likely explanation, say so explicitly.
+- When a benchmark does not execute the changed code directly, say that explicitly instead of implying causal certainty.
+- Avoid calling a small and noisy change a “regression” if the total movement is near zero and the evidence is weak.
+
+## Useful Commands
+
+Use these as patterns, not hard requirements:
+
+```bash
+gh run list --repo <owner/repo> --branch <branch> --workflow CI --limit 10
+gh api repos/<owner>/<repo>/actions/runs/<run-id>/artifacts
+gh run download <run-id> --repo <owner>/<repo> -n <artifact-name> -D /tmp/<dir>
+grep -n '^part:\|^desc: Trigger:\|^totals:' <callgrind.out>
+callgrind_annotate --show=Ir,Dr,Dw,I1mr,D1mr,D1mw,ILmr,DLmr,DLmw --sort=I1mr,D1mr,D1mw <part.out>
+```
+
+For metric interpretation, miss decomposition, and common false-positive patterns, read [references/codspeed-metrics.md](references/codspeed-metrics.md).

--- a/skills/codspeed-regression-analysis/references/codspeed-metrics.md
+++ b/skills/codspeed-regression-analysis/references/codspeed-metrics.md
@@ -1,0 +1,120 @@
+# CodSpeed Metrics and Regression Heuristics
+
+## Core Formulas
+
+CodSpeed simulation mode derives summary metrics from Callgrind totals:
+
+```text
+accesses = Ir + Dr + Dw
+l1_misses = I1mr + D1mr + D1mw
+ll_misses = ILmr + DLmr + DLmw
+estimated_cycles = accesses + 5 * l1_misses + 100 * ll_misses
+```
+
+Field meanings:
+
+- `Ir`: instruction reads
+- `Dr`: data reads
+- `Dw`: data writes
+- `I1mr`: L1 instruction-cache misses
+- `D1mr`: L1 data-read misses
+- `D1mw`: L1 data-write misses
+- `ILmr`: last-level instruction-cache misses
+- `DLmr`: last-level data-read misses
+- `DLmw`: last-level data-write misses
+
+Interpretation:
+
+- `accesses` approximates total work done.
+- `estimated_cycles` approximates total work plus cache penalties.
+
+## How to Read Deltas
+
+### `accesses` up, cache misses roughly flat
+
+Likely explanations:
+
+- More instructions executed
+- More data traversed
+- More hashing, parsing, cloning, formatting, or graph work
+
+This usually points to a direct algorithmic or control-flow expansion.
+
+### `estimated_cycles` up more than `accesses`
+
+Likely explanations:
+
+- Worse cache locality
+- More branchy traversal patterns
+- More pointer chasing
+- Extra allocations or table growth
+
+Treat this as a memory hierarchy problem until proven otherwise.
+
+## How to Interpret L1 Growth
+
+Always decompose L1 growth:
+
+```text
+delta_l1 = delta(I1mr) + delta(D1mr) + delta(D1mw)
+```
+
+### If `I1mr` dominates
+
+Likely explanations:
+
+- Binary code layout changed
+- Hot functions moved across instruction-cache sets
+- More inlining or code-size growth expanded the hot instruction footprint
+- A benchmark started executing a broader set of helper functions than before
+
+This is often an indirect effect. The changed source file may not appear on the hot path.
+
+### If `D1mr` or `D1mw` dominate
+
+Likely explanations:
+
+- Widely carried structs grew
+- Shared metadata became larger
+- Hash maps or vectors reallocated more often
+- Traversal order reduced locality
+- More pointer-heavy structures entered the path
+
+This is where layout-size checks and allocation-path inspection matter.
+
+## Strong Evidence for an Indirect Regression
+
+Treat an explanation as strongly supported when most of these are true:
+
+1. The benchmark does not execute the new feature path directly.
+2. The hot functions are old paths in unchanged files.
+3. The regression is concentrated in `I1mr`, or in `D1` misses with a measurable shared-struct size increase.
+4. Benchmark parity is confirmed, so the delta is not caused by tool or target mismatch.
+
+## Common False Positives
+
+### Invalid baseline
+
+- Different merge base
+- Different benchmark list
+- Different target triple
+- Different CodSpeed mode or tool version
+
+Do not interpret deltas until this is ruled out.
+
+### Broad noise misread as a feature regression
+
+If total accesses and cycles stay nearly flat while only one or two benchmarks move, do not claim a broad project regression.
+
+### New code blamed without execution evidence
+
+If new symbols or files do not appear in the extracted profile, do not present the regression as direct execution of the new feature. Explain the indirect mechanism instead.
+
+## Suggested Root-Cause Language
+
+Use language with the right confidence level:
+
+- “Direct regression”: only when the changed code is on the hot path and materially contributes to the regressed event.
+- “Indirect regression via binary layout”: when `I1mr` dominates and old hotspots worsen without new code executing directly.
+- “Indirect regression via shared-structure growth”: when `D1mr`/`D1mw` dominate and a widely used struct or metadata object measurably grows.
+- “Not enough evidence”: when the comparison is noisy or the baseline is not valid.

--- a/skills/codspeed-regression-analysis/references/codspeed-metrics.md
+++ b/skills/codspeed-regression-analysis/references/codspeed-metrics.md
@@ -25,31 +25,18 @@ Field meanings:
 
 Interpretation:
 
-- `accesses` approximates total work done.
+- `accesses` approximates total work.
 - `estimated_cycles` approximates total work plus cache penalties.
 
 ## How to Read Deltas
 
 ### `accesses` up, cache misses roughly flat
 
-Likely explanations:
-
-- More instructions executed
-- More data traversed
-- More hashing, parsing, cloning, formatting, or graph work
-
-This usually points to a direct algorithmic or control-flow expansion.
+Usually a direct work increase: more instructions, traversal, hashing, parsing, cloning, formatting, or graph work.
 
 ### `estimated_cycles` up more than `accesses`
 
-Likely explanations:
-
-- Worse cache locality
-- More branchy traversal patterns
-- More pointer chasing
-- Extra allocations or table growth
-
-Treat this as a memory hierarchy problem until proven otherwise.
+Usually a cache or memory-hierarchy issue: worse locality, more pointer chasing, more branchy traversal, or more allocation and table growth.
 
 ## How to Interpret L1 Growth
 
@@ -61,30 +48,15 @@ delta_l1 = delta(I1mr) + delta(D1mr) + delta(D1mw)
 
 ### If `I1mr` dominates
 
-Likely explanations:
-
-- Binary code layout changed
-- Hot functions moved across instruction-cache sets
-- More inlining or code-size growth expanded the hot instruction footprint
-- A benchmark started executing a broader set of helper functions than before
-
-This is often an indirect effect. The changed source file may not appear on the hot path.
+Usually an indirect effect: binary layout changed, hot code moved across I-cache sets, inlining or code-size expanded the instruction footprint, or the benchmark now executes a broader helper path.
 
 ### If `D1mr` or `D1mw` dominate
 
-Likely explanations:
-
-- Widely carried structs grew
-- Shared metadata became larger
-- Hash maps or vectors reallocated more often
-- Traversal order reduced locality
-- More pointer-heavy structures entered the path
-
-This is where layout-size checks and allocation-path inspection matter.
+Usually a data-layout issue: shared structs grew, metadata got larger, containers reallocated more, traversal order got worse, or pointer-heavy structures entered the path.
 
 ## Strong Evidence for an Indirect Regression
 
-Treat an explanation as strongly supported when most of these are true:
+Treat an explanation as strong when most of these are true:
 
 1. The benchmark does not execute the new feature path directly.
 2. The hot functions are old paths in unchanged files.


### PR DESCRIPTION
## Summary

Add a new `codspeed-regression-analysis` skill for evidence-based CodSpeed slowdown analysis from GitHub Actions artifacts and Callgrind outputs.

## What this skill covers

- Verifying whether a PR run and baseline run are actually comparable
- Downloading and inspecting `codspeed-valgrind-tmp-*` artifacts
- Extracting per-benchmark `totals` from merged Callgrind outputs
- Computing `accesses` and `estimated_cycles`
- Separating instruction-cache and data-cache regressions
- Distinguishing direct hot-path regressions from indirect binary/data-layout effects
- Producing a concise root-cause report with excluded explanations

## Files

- `skills/codspeed-regression-analysis/SKILL.md`
- `skills/codspeed-regression-analysis/references/codspeed-metrics.md`
- `README.md`

## Validation

- `npx prettier -c skills/codspeed-regression-analysis/SKILL.md skills/codspeed-regression-analysis/references/codspeed-metrics.md README.md`
- pre-commit `pnpm run lint:write` ran successfully during commit
