### PR TITLE
feat: add interop externals note to rstest migration skill

### DIFF
--- a/skills/migrate-to-rstest/SKILL.md
+++ b/skills/migrate-to-rstest/SKILL.md
@@ -82,6 +82,17 @@ stop and provide:
 
 - Run the test suite and fix failures iteratively.
 - Fix configuration and resolver errors first, then address mocks/timers/snapshots, and touch test logic last.
+- If a third-party package fails because of ESM/CJS interop differences, prefer a config-level fix first by overriding its external module type in the test/build config, for example:
+
+```ts
+output: {
+   externals: {
+      'fs-extra': 'commonjs fs-extra',
+   },
+},
+```
+
+   Use this when a dependency is being interpreted as the wrong module format under Rstest/Rspack.
 - If mocks fail for re-exported modules under Rspack, first check whether the project is pinned to `rstest < 0.9.3` (fixed in 0.9.3 — upgrade before debugging mock behavior further).
 
 ## Summarize changes

--- a/skills/migrate-to-rstest/SKILL.md
+++ b/skills/migrate-to-rstest/SKILL.md
@@ -92,7 +92,8 @@ output: {
 },
 ```
 
-   Use this when a dependency is being interpreted as the wrong module format under Rstest/Rspack.
+Use this when a dependency is being interpreted as the wrong module format under Rstest/Rspack.
+
 - If mocks fail for re-exported modules under Rspack, first check whether the project is pinned to `rstest < 0.9.3` (fixed in 0.9.3 — upgrade before debugging mock behavior further).
 
 ## Summarize changes


### PR DESCRIPTION
## Summary
This PR updates the migrate-to-rstest skill to document a config-level fix for third-party ESM/CJS interop issues under Rstest/Rspack. It recommends overriding the external module type with output.externals before changing test code, and includes an fs-extra example.