### PR TITLE
chore(ci): pin workflow actions to commit SHAs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,12 @@
 {
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
-  extends: ['config:base', 'schedule:monthly', 'group:allNonMajor', 'helpers:pinGitHubActionDigests', 'github>rstackjs/renovate:security'],
+  extends: [
+    'config:base',
+    'schedule:monthly',
+    'group:allNonMajor',
+    'helpers:pinGitHubActionDigests',
+    'github>rstackjs/renovate:security',
+  ],
   rangeStrategy: 'bump',
   packageRules: [{ depTypeList: ['peerDependencies'], enabled: false }],
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,6 @@
 {
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
-  extends: ['config:base', 'schedule:monthly', 'group:allNonMajor'],
+  extends: ['config:base', 'schedule:monthly', 'group:allNonMajor', 'helpers:pinGitHubActionDigests', 'github>rstackjs/renovate:security'],
   rangeStrategy: 'bump',
   packageRules: [{ depTypeList: ['peerDependencies'], enabled: false }],
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,15 +19,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
           version: 10.28.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24.13.0
           cache: pnpm

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,7 +28,7 @@ jobs:
           corepack enable
 
       - name: Setup Node.js
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           package-manager-cache: false


### PR DESCRIPTION
## Summary
This PR pins external GitHub Actions in the workflow files to full commit SHAs so the repository complies with the action pinning policy. It also aligns shared actions across CI and lint workflows so both jobs use the same reviewed action revisions.

Add helpers:pinGitHubActionDigests to let renovate automatically pin action digests. 