### PR TITLE
fix(rstest): use rs API namespace in skills

### DIFF
--- a/skills-test/migrate-to-rstest/evals/evals.json
+++ b/skills-test/migrate-to-rstest/evals/evals.json
@@ -30,8 +30,8 @@
         "moduleNameMapper alias translated to rstest alias",
         "CSS module moduleNameMapper translated (CSS imports still resolve to identity-like string map or equivalent)",
         "coverageThreshold translated to rstest coverage thresholds (lines>=80, functions>=80, branches>=70, statements>=80)",
-        "jest.<api> usages literally replaced with rstest.<api> in test files (no globalThis.jest shim)",
-        "jest.mock factory translated to rstest.mock equivalent",
+        "jest.<api> usages literally replaced with rs.<api> in test files (no globalThis.jest shim)",
+        "jest.mock factory translated to rs.mock equivalent",
         "Bare jest.mock('@app/logger') + src/__mocks__/logger.ts pattern still works (either preserved or equivalent auto-mock setup)",
         "jest deps and jest.config.js not deleted before Rstest is green",
         "Post-migration pnpm test: 12 tests pass across 5 files with coverage thresholds met"
@@ -159,7 +159,7 @@
           "setupFiles (jest.polyfills.ts — matchMedia) split from setupFilesAfterEnv (jest.setup.ts — jest-dom matchers / custom matcher via expect.extend)"
         ]
       },
-      "prompt": "Migrate this pnpm monorepo Jest multi-project setup to Rstest. The root jest.config.js uses `projects: ['<rootDir>/packages/node-lib', '<rootDir>/packages/dom-lib']` plus `globalSetup` / `globalTeardown` (seeds and tears down `process.env.__DB_SEED__`) and a root `coverageThreshold`. Each project has its own jest.config.js with: displayName (object form, {name, color}), preset 'ts-jest', its own testEnvironment (node vs jsdom), setupFilesAfterEnv, clearMocks, collectCoverageFrom. dom-lib additionally sets testEnvironmentOptions (url: 'https://app.example.com/dashboard', userAgent: 'FixtureAgent/1.0', pretendToBeVisual: true), setupFiles (jest.polyfills.ts — polyfills matchMedia before framework) separate from setupFilesAfterEnv (jest.setup.ts — imports @testing-library/jest-dom). node-lib's jest.setup.ts both hydrates globalThis.__DB__ from process.env.__DB_SEED__ and registers a custom matcher via expect.extend (with declare global namespace jest for types). Migrate the whole setup to Rstest: projects top-level, globalSetup/globalTeardown preserved (Rstest globalSetup returns the teardown fn), jest-dom matchers via expect.extend, jest-specific types/namespaces replaced with Rstest equivalents, jest.<api> -> rstest.<api> if any appear. Coverage thresholds must still be enforced (use @rstest/coverage-istanbul). Keep Jest deps and configs until Rstest is green.",
+      "prompt": "Migrate this pnpm monorepo Jest multi-project setup to Rstest. The root jest.config.js uses `projects: ['<rootDir>/packages/node-lib', '<rootDir>/packages/dom-lib']` plus `globalSetup` / `globalTeardown` (seeds and tears down `process.env.__DB_SEED__`) and a root `coverageThreshold`. Each project has its own jest.config.js with: displayName (object form, {name, color}), preset 'ts-jest', its own testEnvironment (node vs jsdom), setupFilesAfterEnv, clearMocks, collectCoverageFrom. dom-lib additionally sets testEnvironmentOptions (url: 'https://app.example.com/dashboard', userAgent: 'FixtureAgent/1.0', pretendToBeVisual: true), setupFiles (jest.polyfills.ts — polyfills matchMedia before framework) separate from setupFilesAfterEnv (jest.setup.ts — imports @testing-library/jest-dom). node-lib's jest.setup.ts both hydrates globalThis.__DB__ from process.env.__DB_SEED__ and registers a custom matcher via expect.extend (with declare global namespace jest for types). Migrate the whole setup to Rstest: projects top-level, globalSetup/globalTeardown preserved (Rstest globalSetup returns the teardown fn), jest-dom matchers via expect.extend, jest-specific types/namespaces replaced with Rstest equivalents, jest.<api> -> rs.<api> if any appear. Coverage thresholds must still be enforced (use @rstest/coverage-istanbul). Keep Jest deps and configs until Rstest is green.",
       "assertions": [
         "Root rstest.config.ts with projects at top level of defineConfig",
         "Per-package rstest.config.ts with correct environment (node-lib=node, dom-lib=jsdom)",
@@ -171,7 +171,7 @@
         "dom-lib setupFiles (matchMedia polyfill) runs before framework; setupFilesAfterEnv (jest-dom) runs after — both still wired",
         "node-lib setupFilesAfterEnv hydrates globalThis.__DB__ from env + registers custom matcher via expect.extend",
         "Jest types/namespaces for custom matcher (declare global namespace jest) migrated to Rstest-compatible declaration",
-        "jest.<api> -> rstest.<api> literal replacement in any test code (no globalThis.jest shim, no `rstest as jest` alias)",
+        "jest.<api> -> rs.<api> literal replacement in any test code (no globalThis.jest shim, no `rs as jest` alias)",
         "Jest deps/configs not deleted before Rstest is green; old jest.config.js / jest.global-setup.ts / jest.global-teardown.ts / per-package jest.config.js removed after green",
         "Post-migration pnpm test: 8 tests pass across 2 files covering both projects with coverage thresholds met"
       ]

--- a/skills-test/rstest-best-practices/evals/evals.json
+++ b/skills-test/rstest-best-practices/evals/evals.json
@@ -28,7 +28,7 @@
       "fixture": "fetch-with-retry",
       "prompt": "This is a Node.js TypeScript package. `src/api/fetchUserProfile.ts` exports `fetchUserProfile(userId: string): Promise<UserProfile>`. Internally it calls `globalThis.fetch('https://api.example.com/users/' + userId)`, retries up to 3 attempts on 5xx responses, and throws `ApiError` if the final attempt also fails. `test/fetchUserProfile.test.ts` is empty. `rstest.config.ts` uses Node env. Write tests covering: (a) first call returns 200 with valid body — function resolves, (b) two 500s then third returns 200 — function still resolves (retry path), (c) all three attempts return 500 — function throws ApiError. Do not make real HTTP calls. All tests must pass.",
       "assertions": [
-        "Uses rstest.spyOn(globalThis, 'fetch') OR module-level rstest.mock('./api' or similar) to intercept fetch — no real network call",
+        "Uses rs.spyOn(globalThis, 'fetch') OR module-level rs.mock('./api' or similar) to intercept fetch — no real network call",
         "Sequential responses scripted with mockResolvedValueOnce (or mockImplementationOnce) chained, not a manual counter variable",
         "Error path asserted via .rejects.toThrow() or await expect(...).rejects.toXxx — not try/catch + expect.fail",
         "Mock restoration: either afterEach with restoreAllMocks/mockRestore, OR config sets restoreMocks: true / clearMocks: true",
@@ -43,11 +43,11 @@
       "fixture": "debounce-fake-timers",
       "prompt": "This is a TypeScript utility package. `src/debounce.ts` implements `debounce(fn, wait)` with trailing-edge semantics and a `.cancel()` method. `test/debounce.test.ts` already has one test that uses real `setTimeout` to wait 500ms, making it slow and occasionally flaky on CI. Rewrite the test using Rstest fake timers and add the following coverage: (a) multiple calls within the wait window trigger the underlying fn only once with the last arguments, (b) a new call within the wait window resets the timer (the fn fires `wait` ms after the LAST call), (c) calling `.cancel()` before the timer fires prevents invocation. The rewritten test must pass in well under one second.",
       "assertions": [
-        "Uses rstest.useFakeTimers() (in beforeEach or at test scope)",
-        "Uses rstest.useRealTimers() in afterEach (or at end of test) to avoid leaking fake timers into later files",
-        "Uses rstest.advanceTimersByTime for time progression (not a blanket runAllTimers when testing boundary semantics)",
+        "Uses rs.useFakeTimers() (in beforeEach or at test scope)",
+        "Uses rs.useRealTimers() in afterEach (or at end of test) to avoid leaking fake timers into later files",
+        "Uses rs.advanceTimersByTime for time progression (not a blanket runAllTimers when testing boundary semantics)",
         "No `new Promise(r => setTimeout(r, ...))`, no `await sleep(...)`, no other real-time wait patterns in the test file",
-        "The debounced callback is wrapped in rstest.fn() for call-count/args assertions",
+        "The debounced callback is wrapped in rs.fn() for call-count/args assertions",
         "Covers all three scenarios (multi-call collapse, timer reset on new call, cancel prevents)",
         "pnpm test passes and completes in under 1 second (indicates no real waits)"
       ]
@@ -60,7 +60,7 @@
       "assertions": [
         "Uses render from @testing-library/react (or re-export) to mount the component",
         "Uses semantic queries: getByRole / getByLabelText for inputs and button — not getByTestId for elements that have a semantic role",
-        "onSubmit prop passed as rstest.fn().mockResolvedValue(...) — not a real async function",
+        "onSubmit prop passed as rs.fn().mockResolvedValue(...) — not a real async function",
         "Async UI states asserted via findBy* or waitFor — not via manual setTimeout / arbitrary await",
         "jest-dom matchers used (toBeInTheDocument, toHaveValue, toBeDisabled, etc.) instead of raw DOM property reads",
         "User interaction uses fireEvent OR @testing-library/user-event (either is acceptable) — not manual element.click() / .value = ...",
@@ -89,8 +89,8 @@
       "fixture": "esm-partial-mock-router",
       "prompt": "This React + react-router-dom v6 project has `src/pages/Product.tsx` that reads `:id` via `useParams()` and renders `Product {id}`. The developer wants to unit-test the component without wrapping it in a `MemoryRouter` — instead mocking only `useParams` to return `{ id: 'p-42' }` while keeping all other react-router-dom exports (MemoryRouter, Link, etc.) working so any other consumers in the rendered tree continue to function. `rstest.config.ts` has pluginReact() + testEnvironment happy-dom. `src/pages/Product.test.tsx` is empty. Write a passing test.",
       "assertions": [
-        "rstest.mock call is at module scope (top of file), targeting 'react-router-dom' (or 'react-router' as the true export source)",
-        "Factory preserves non-mocked exports via spreading `...actual` obtained through import attribute `with { rstest: 'importActual' }` OR via rstest.importActual()",
+        "rs.mock call is at module scope (top of file), targeting 'react-router-dom' (or 'react-router' as the true export source)",
+        "Factory preserves non-mocked exports via spreading `...actual` obtained through import attribute `with { rstest: 'importActual' }` OR via rs.importActual()",
         "Only useParams is overridden; MemoryRouter / Link / other exports are not replaced",
         "Mock factory does not reference test-scope variables that are defined AFTER it (respects hoisting)",
         "Test does NOT wrap the component in MemoryRouter / BrowserRouter / any router provider",
@@ -104,7 +104,7 @@
       "fixture": "cjs-mock-memfs",
       "prompt": "This is a CommonJS Node.js CLI tool (package.json has `\"type\": \"commonjs\"`). `src/reportWriter.cjs` does `const fs = require('node:fs')` and writes JSON to `path.join(cwd, 'report.json')` via `fs.writeFileSync`. The developer wants to test the function without writing to the real disk, using `memfs` to provide an in-memory filesystem. `tests/reportWriter.test.cjs` currently has a failing placeholder; `memfs` is installed. `rstest.config.cjs` has include pattern for *.test.cjs. Write a passing test that verifies the function wrote the expected JSON content without touching the real filesystem.",
       "assertions": [
-        "Uses rstest.mockRequire (not rstest.mock) to intercept the fs module — matches the require() loading path used by the CJS source",
+        "Uses rs.mockRequire (not rs.mock) to intercept the fs module — matches the require() loading path used by the CJS source",
         "Mocks 'node:fs' (or whichever specifier the source uses) via memfs",
         "No real files written to disk during the test run (no cleanup needed on real paths)",
         "Volume / fs state is reset between tests (vol.reset() or equivalent in beforeEach / afterEach)",

--- a/skills/migrate-to-rstest/references/global-api-migration.md
+++ b/skills/migrate-to-rstest/references/global-api-migration.md
@@ -12,9 +12,9 @@ The rules below are skill-side enforcement on top of that mapping.
 ## Red lines
 
 1. **No shims.** All three forms below leave the migration incomplete and must be rejected in every test and setup file:
-   - `globalThis.vi = rs;` / `global.jest = rstest;` (direct global aliasing)
-   - `const vi = rs;` / `const jest = rstest;` (local rebinding)
-   - `import { rs as vi } from '@rstest/core';` / `import { rstest as jest } from '@rstest/core';` (aliased named import)
+   - `globalThis.vi = rs;` / `global.jest = rs;` (direct global aliasing)
+   - `const vi = rs;` / `const jest = rs;` (local rebinding)
+   - `import { rs as vi } from '@rstest/core';` / `import { rs as jest } from '@rstest/core';` (aliased named import)
 
    Fix at every call site instead. Do not propose a shim "just to keep the diff small" — it hides whether the migration actually happened, blocks IDE refactors, and silences future deprecation warnings.
 


### PR DESCRIPTION
This PR updates Rstest skill guidance and eval assertions to use the current `rs.*` API namespace instead of the outdated `rstest.*` examples. It also adjusts the migration red-line examples so Jest and Vitest global API replacements consistently point to `rs` while leaving config filenames, package names, and docs URLs unchanged.