### PR TITLE
chore(ci): optimize pnpm setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,19 +21,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
-        with:
-          version: 10.28.2
-
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24.13.0
-          cache: pnpm
+          package-manager-cache: false
 
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Install Pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          run_install: true
 
       - name: Run build
         run: pnpm build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,19 +22,16 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Install Pnpm
-        run: |
-          npm install -g corepack@latest --force
-          corepack enable
-
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           package-manager-cache: false
 
-      - name: Install Dependencies
-        run: pnpm install
+      - name: Install Pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          run_install: true
 
       - name: Lint
         run: pnpm lint


### PR DESCRIPTION
## Summary

- Replace custom/corepack pnpm setup in CI workflows with pnpm/action-setup v6 and run_install.
- Disable setup-node package manager cache to match the optimized pnpm setup.

## Related PR

- Refs rstackjs/rsbuild-plugin-virtual-module#32

## Testing

- pnpm exec prettier -c .github/workflows/ci.yml .github/workflows/lint.yml
- pnpm build
- pnpm lint
- git diff --check
