### PR TITLE
docs: refine Rstest migration skill

### DIFF
--- a/skills/migrate-to-rstest/SKILL.md
+++ b/skills/migrate-to-rstest/SKILL.md
@@ -40,7 +40,7 @@ Migrate Jest- or Vitest-based tests and config to Rstest with minimal behavior c
 - Rstest `globals` defaults to `false`; if globals remain, set `globals: true` and add `@rstest/core/globals` types.
 - For latest Rstest, use `defineInlineProject({ name, ... })` for object entries inside `projects`; for Rstest 0.8.x, use plain named objects because `defineInlineProject` is unavailable. Use `defineProject` for top-level project config files.
 - Coverage providers require Rstest packages (`@rstest/coverage-istanbul` or `@rstest/coverage-v8`); `coverage.reporters` is plural.
-- `detectAsyncLeaks` is only replacement-adjacent for leaked async resources, not a drop-in `detectOpenHandles` clone.
+- `detectAsyncLeaks` is only replacement-adjacent for leaked async resources, not a drop-in `detectOpenHandles` clone. It requires Rstest >= 0.10.1, so omit it for Rstest 0.8.x migrations unless the user accepts a toolchain upgrade.
 - Rstest runs on Rsbuild/Rspack. Prefer `output.bundleDependencies`, `output.externals`, aliases, adapters, or Rsbuild plugins before changing tests.
 - Version compatibility matters: latest Rstest uses Rsbuild/Rspack 2.x; Rstest 0.8.x uses Rsbuild/Rspack 1.x. Choose adapters and Rsbuild plugins by peer dependency compatibility, not package-name major equality.
 

--- a/skills/migrate-to-rstest/SKILL.md
+++ b/skills/migrate-to-rstest/SKILL.md
@@ -38,11 +38,11 @@ Migrate Jest- or Vitest-based tests and config to Rstest with minimal behavior c
 
 - Plain `rstest` / `rstest run` is single-run mode; watch mode is `rstest --watch` or `rstest watch`.
 - Rstest `globals` defaults to `false`; if globals remain, set `globals: true` and add `@rstest/core/globals` types.
-- Use `defineInlineProject({ name, ... })` for object entries inside `projects`; use `defineProject` for top-level project config files.
+- For latest Rstest, use `defineInlineProject({ name, ... })` for object entries inside `projects`; for Rstest 0.8.x, use plain named objects because `defineInlineProject` is unavailable. Use `defineProject` for top-level project config files.
 - Coverage providers require Rstest packages (`@rstest/coverage-istanbul` or `@rstest/coverage-v8`); `coverage.reporters` is plural.
 - `detectAsyncLeaks` is only replacement-adjacent for leaked async resources, not a drop-in `detectOpenHandles` clone.
 - Rstest runs on Rsbuild/Rspack. Prefer `output.bundleDependencies`, `output.externals`, aliases, adapters, or Rsbuild plugins before changing tests.
-- Version compatibility matters: latest Rstest uses Rsbuild/Rspack 2.x; Rstest 0.8.x uses Rsbuild/Rspack 1.x. Keep `@rstest/*`, `@rsbuild/*`, `@rspack/*`, `@rslib/*`, and `@rsbuild/plugin-*` majors aligned.
+- Version compatibility matters: latest Rstest uses Rsbuild/Rspack 2.x; Rstest 0.8.x uses Rsbuild/Rspack 1.x. Choose adapters and Rsbuild plugins by peer dependency compatibility, not package-name major equality.
 
 ## Escalate before large edits
 

--- a/skills/migrate-to-rstest/SKILL.md
+++ b/skills/migrate-to-rstest/SKILL.md
@@ -1,102 +1,49 @@
 ---
 name: migrate-to-rstest
-description: Migrate Jest or Vitest test suites and configs to Rstest. Use when asked to move from Jest/Vitest to Rstest, replace framework APIs with `@rstest/core`, translate test config to `rstest.config.ts`, or update test scripts and setup files for Rstest equivalents.
+description: Migrate Jest or Vitest projects to Rstest. Use when asked to move from Jest/Vitest to Rstest, replace `jest`/`vi` APIs with `@rstest/core`, translate config into `rstest.config.ts`, update scripts/coverage/setup/mocks/snapshots/projects, or diagnose migration failures caused by Rstest's Rsbuild/Rspack execution model or version skew.
 ---
 
 # Migrate to Rstest
 
 ## Goal
 
-Migrate Jest- or Vitest-based tests and configuration to Rstest with minimal behavior changes.
-
-## Migration principles (must follow)
-
-1. **Smallest-change-first**: prefer the smallest viable change that restores test pass.
-2. **Config before code**: prefer fixing in config/tooling/mocks before touching test logic.
-3. **Do not change user source behavior**: avoid modifying production/business source files unless user explicitly requests it.
-4. **Avoid bulk test rewrites**: do not refactor entire test suites when a local compatibility patch can solve it.
-5. **Preserve test intent**: keep assertions and scenario coverage unchanged unless clearly broken by framework differences.
-6. **Two-phase legacy-runner lifecycle (per migrated scope)**: (a) While the scope being migrated is not green on Rstest, keep every Jest/Vitest dep + config/setup/workspace file untouched — they are your rollback path. (b) Once that scope is green, delete its scope-local legacy config/setup files in the same commit. Drop the shared legacy devDeps (`jest`, `vitest`, adapters, environments) only when no other scope still relies on them — in a partial / mixed-mode monorepo migration that means the final scope, not the first. Leaving files behind "for reference" creates two source-of-truth configs. Framework-specific file enumeration: see the deltas reference.
-7. **Literal API substitution, no shims**: rewrite every `vi.` / `jest.` / `vitest.` call site — no global aliasing, no local rebinding, no aliased imports. Full forbidden-form list and reasoning in `references/global-api-migration.md`.
-8. **Replace on call sites, not strings**: match only identifiers preceding `(`; after every batch edit, grep `describe\(|it\(|test\(` to confirm no test name string was mutated. Regex template and rationale in `references/global-api-migration.md`.
-9. **Coverage thresholds are not negotiable**: never lower `coverage.thresholds` (lines/functions/branches/statements) to make a migrated suite pass. If thresholds fail under Rstest, investigate `coverage.include` / `exclude` / provider wiring before touching the numbers.
+Migrate Jest- or Vitest-based tests and config to Rstest with minimal behavior changes. Treat the current Rstest migration docs as the source of truth; this skill adds guardrails for scope, cleanup, and common migration traps.
 
 ## Workflow
 
-1. Detect current test framework (`references/detect-test-framework.md`)
-2. Dependency install gate (blocker check, see `references/dependency-install-gate.md`)
-3. Open the framework-specific deltas file and the official migration guide it points to. Prefer the `.md` URL form when fetching — Rstest pages provide Markdown variants that are more AI-friendly.
+1. Detect the runner and smallest migration scope (`references/detect-test-framework.md`).
+2. Run the dependency/install gate, including Rstest/Rsbuild/Rspack/plugin major compatibility (`references/dependency-install-gate.md`).
+3. Read the framework-specific delta file, then consult the official/local Rstest guide for exact mappings:
    - Jest: `references/jest-migration-deltas.md`
    - Vitest: `references/vitest-migration-deltas.md`
-   - Global API replacement rules: `references/global-api-migration.md`
-4. Apply the mapping from the official guide + the skill-side enforcement rules from the deltas file
-5. Check type errors
-6. Run tests and fix deltas
-7. Apply cleanup phase of principle 6 once the migrated scope is green (delete scope-local legacy config/setup in the same commit; drop shared legacy devDeps only when no other scope still relies on them; framework-specific file list is in the deltas file)
-8. Summarize changes
+   - Global API replacement: `references/global-api-migration.md`
+4. Migrate scripts/config/setup before tests. Prefer adapters for existing Rsbuild/Rslib/Rspack projects.
+5. Check types and test discovery (`rstest list --filesOnly` is useful before a full run).
+6. Run Rstest and fix failures in this order: dependency/version skew, config/resolver, setup/env/coverage, mocks/timers/snapshots, test bodies last.
+7. When the migrated scope is green, remove only its scope-local legacy runner files. Drop shared Jest/Vitest devDeps only when no scope still uses them.
+8. Summarize files changed, legacy files kept/removed, unsupported fields, and remaining TODOs.
 
-## Detect current test framework
+## Non-negotiable guardrails
 
-See `references/detect-test-framework.md` for detection signals and the mixed-mode scope policy.
+- Prefer the smallest viable change and fix config/tooling before test logic.
+- Do not modify production/business source behavior unless the user explicitly asks.
+- Do not bulk-rewrite tests when a local config/setup/mock fix is plausible.
+- Preserve assertions, scenario coverage, and coverage thresholds. Never lower thresholds to pass migration.
+- No `jest`/`vi` shims or aliases. Rewrite call sites to Rstest APIs; see `references/global-api-migration.md`.
+- Do not mutate test name strings while replacing APIs.
+- Do not silently drop unknown config fields. Verify against docs or call them out as unsupported.
+- Do not broaden a monorepo migration beyond the chosen package/suite/project.
 
-## Dependency install gate (blocker check)
+## High-risk Rstest deltas
 
-Before large-scale edits, verify dependencies can be installed and test runner binaries are available. Detailed checks, blocked-mode output format, and `ni` policy are in `references/dependency-install-gate.md`.
+- Plain `rstest` / `rstest run` is single-run mode; watch mode is `rstest --watch` or `rstest watch`.
+- Rstest `globals` defaults to `false`; if globals remain, set `globals: true` and add `@rstest/core/globals` types.
+- Use `defineInlineProject({ name, ... })` for object entries inside `projects`; use `defineProject` for top-level project config files.
+- Coverage providers require Rstest packages (`@rstest/coverage-istanbul` or `@rstest/coverage-v8`); `coverage.reporters` is plural.
+- `detectAsyncLeaks` is only replacement-adjacent for leaked async resources, not a drop-in `detectOpenHandles` clone.
+- Rstest runs on Rsbuild/Rspack. Prefer `output.bundleDependencies`, `output.externals`, aliases, adapters, or Rsbuild plugins before changing tests.
+- Version compatibility matters: latest Rstest uses Rsbuild/Rspack 2.x; Rstest 0.8.x uses Rsbuild/Rspack 1.x. Keep `@rstest/*`, `@rsbuild/*`, `@rspack/*`, `@rslib/*`, and `@rsbuild/plugin-*` majors aligned.
 
-## Patch scope policy (strict)
+## Escalate before large edits
 
-### Preferred change order
-
-1. CLI/script/config migration (`package.json`, `rstest.config.ts`, include/exclude, test environment).
-2. Test setup adapter migration (for example `@testing-library/jest-dom/vitest` to matcher-based setup in Rstest).
-3. Mock compatibility adjustments (target module path, `{ mock: true }`, `importActual`).
-4. Narrow per-test setup fixes (single-file, single-suite level).
-5. Path resolution compatibility fixes (`import.meta.url` vs `__dirname`) in test/setup helpers.
-6. As a last resort, test body changes.
-7. Never modify runtime source logic by default.
-
-### Red lines
-
-Principles 6–9 above are themselves red lines — the bullets below cover the scope / intent red lines not captured there:
-
-- Do not rewrite many tests in one sweep without first proving config-level fixes are insufficient.
-- Do not alter business/runtime behavior to satisfy tests.
-- Do not change assertion semantics just to make tests pass.
-- Do not broaden migration to unrelated packages in a monorepo.
-
-### Escalation rule for large edits
-
-If a fix would require either:
-
-- editing many test files, or
-- changing user source files,
-
-stop and provide:
-
-1. why minimal fixes failed,
-2. proposed large-change options,
-3. expected impact/risk per option,
-4. recommended option.
-
-## Run tests and fix deltas
-
-- Run the test suite and fix failures iteratively.
-- Fix configuration and resolver errors first, then address mocks/timers/snapshots, and touch test logic last.
-- If a third-party package fails because of ESM/CJS interop differences, prefer a config-level fix first by overriding its external module type in the test/build config, for example:
-
-```ts
-output: {
-   externals: {
-      'fs-extra': 'commonjs fs-extra',
-   },
-},
-```
-
-Use this when a dependency is being interpreted as the wrong module format under Rstest/Rspack.
-
-- If mocks fail for re-exported modules under Rspack, first check whether the project is pinned to `rstest < 0.9.3` (fixed in 0.9.3 — upgrade before debugging mock behavior further).
-
-## Summarize changes
-
-- Provide a concise change summary and list files touched.
-- Call out any remaining manual steps or TODOs.
+If the next fix requires many test edits or production source changes, stop and report: why smaller fixes failed, options, risks, and the recommended path.

--- a/skills/migrate-to-rstest/SKILL.md
+++ b/skills/migrate-to-rstest/SKILL.md
@@ -7,42 +7,30 @@ description: Migrate Jest or Vitest projects to Rstest. Use when asked to move f
 
 ## Goal
 
-Migrate Jest- or Vitest-based tests and config to Rstest with minimal behavior changes. Treat the current Rstest migration docs as the source of truth; this skill adds guardrails for scope, cleanup, and common migration traps.
+Migrate Jest/Vitest tests and config to Rstest with minimal behavior changes. Use the current Rstest migration docs for exact mappings; this skill adds scope, dependency, and cleanup guardrails.
 
 ## Workflow
 
-1. Detect the runner and smallest migration scope (`references/detect-test-framework.md`).
-2. Run the dependency/install gate, including Rstest/Rsbuild/Rspack/plugin major compatibility (`references/dependency-install-gate.md`).
-3. Read the framework-specific delta file, then consult the official/local Rstest guide for exact mappings:
-   - Jest: `references/jest-migration-deltas.md`
-   - Vitest: `references/vitest-migration-deltas.md`
-   - Global API replacement: `references/global-api-migration.md`
-4. Migrate scripts/config/setup before tests. Prefer adapters for existing Rsbuild/Rslib/Rspack projects.
-5. Check types and test discovery (`rstest list --filesOnly` is useful before a full run).
-6. Run Rstest and fix failures in this order: dependency/version skew, config/resolver, setup/env/coverage, mocks/timers/snapshots, test bodies last.
-7. When the migrated scope is green, remove only its scope-local legacy runner files. Drop shared Jest/Vitest devDeps only when no scope still uses them.
-8. Summarize files changed, legacy files kept/removed, unsupported fields, and remaining TODOs.
+1. Detect runner and scope (`references/detect-test-framework.md`).
+2. Run dependency/version gates (`references/dependency-install-gate.md`).
+3. Read only the needed deltas: Jest, Vitest, and/or global API replacement.
+4. Migrate scripts/config/setup before tests; prefer adapters or Rsbuild/Rspack config fixes before editing test bodies.
+5. Validate discovery/types/run, fixing failures in this order: dependency skew, config/resolver, setup/env/coverage, mocks/timers/snapshots, test bodies.
+6. After the scope is green, remove only scope-local legacy files and devDeps no remaining scope uses.
+7. Summarize changes, kept legacy files, unsupported fields, and TODOs.
 
-## Non-negotiable guardrails
+## Guardrails
 
-- Prefer the smallest viable change and fix config/tooling before test logic.
-- Do not modify production/business source behavior unless the user explicitly asks.
-- Do not bulk-rewrite tests when a local config/setup/mock fix is plausible.
-- Preserve assertions, scenario coverage, and coverage thresholds. Never lower thresholds to pass migration.
-- No `jest`/`vi` shims or aliases. Rewrite call sites to Rstest APIs; see `references/global-api-migration.md`.
-- Do not mutate test name strings while replacing APIs.
-- Do not silently drop unknown config fields. Verify against docs or call them out as unsupported.
-- Do not broaden a monorepo migration beyond the chosen package/suite/project.
+- Keep the smallest viable scope; do not broaden a monorepo migration or bulk-rewrite tests when config/setup fixes are plausible.
+- Do not change production behavior, assertions, test names, scenarios, or coverage thresholds to make migration pass.
+- No `jest`/`vi` shims or aliases; rewrite call sites to Rstest APIs (`references/global-api-migration.md`).
+- Do not silently drop unknown config fields; verify or report them as unsupported.
 
 ## High-risk Rstest deltas
 
-- Plain `rstest` / `rstest run` is single-run mode; watch mode is `rstest --watch` or `rstest watch`.
-- Rstest `globals` defaults to `false`; if globals remain, set `globals: true` and add `@rstest/core/globals` types.
-- For latest Rstest, use `defineInlineProject({ name, ... })` for object entries inside `projects`; for Rstest 0.8.x, use plain named objects because `defineInlineProject` is unavailable. Use `defineProject` for top-level project config files.
-- Coverage providers require Rstest packages (`@rstest/coverage-istanbul` or `@rstest/coverage-v8`); `coverage.reporters` is plural.
-- `detectAsyncLeaks` is only replacement-adjacent for leaked async resources, not a drop-in `detectOpenHandles` clone. It requires Rstest >= 0.10.1, so omit it for Rstest 0.8.x migrations unless the user accepts a toolchain upgrade.
-- Rstest runs on Rsbuild/Rspack. Prefer `output.bundleDependencies`, `output.externals`, aliases, adapters, or Rsbuild plugins before changing tests.
-- Version compatibility matters: latest Rstest uses Rsbuild/Rspack 2.x; Rstest 0.8.x uses Rsbuild/Rspack 1.x. Choose adapters and Rsbuild plugins by peer dependency compatibility, not package-name major equality.
+- `rstest` / `rstest run` is single-run; watch mode is `rstest --watch` or `rstest watch`.
+- `globals` defaults to `false`; if globals remain, set `globals: true` and add `@rstest/core/globals` types.
+- Rstest runs on Rsbuild/Rspack. Use `references/dependency-install-gate.md` for latest-only APIs, coverage providers, adapters, plugins, and toolchain-version fallbacks.
 
 ## Escalate before large edits
 

--- a/skills/migrate-to-rstest/references/dependency-install-gate.md
+++ b/skills/migrate-to-rstest/references/dependency-install-gate.md
@@ -9,7 +9,7 @@ Use the repository's native package manager instead of adding another package ju
 Detect the manager from existing project signals, in this order:
 
 1. `package.json#packageManager`
-2. Lockfile: `pnpm-lock.yaml`, `yarn.lock`, `package-lock.json`, `npm-shrinkwrap.json`, or `bun.lockb`
+2. Lockfile: `pnpm-lock.yaml`, `yarn.lock`, `package-lock.json`, `npm-shrinkwrap.json`, `bun.lock`, or `bun.lockb`
 3. Existing CI/test scripts or workspace files such as `pnpm-workspace.yaml` or `.yarnrc.yml`
 
 Then install with that manager. For example, in a pnpm repo:
@@ -24,7 +24,7 @@ After adding `@rstest/core`, verify Rstest through the same local manager path w
 pnpm exec rstest -h
 ```
 
-For npm-only repos, run `./node_modules/.bin/rstest -h` directly, or use `npm exec -- rstest -h` after local install. In Yarn/Bun repos, use the repo's local binary execution path only when it resolves the installed dependency.
+For npm-only repos, run `./node_modules/.bin/rstest -h` directly so the check cannot fall back to a remote package. In Yarn/Bun repos, use the repo's local binary execution path only when it resolves the installed dependency.
 
 If a package manager script already exists after the script migration, also prefer the repo-native script (for example `pnpm test -- --help` only when that is how the repo runs tests).
 
@@ -33,9 +33,9 @@ If a package manager script already exists after the script migration, also pref
 Install only packages the migrated scope needs:
 
 - Always add `@rstest/core` as a dev dependency for a migrated scope.
-- If coverage is enabled, add a Rstest provider supported by the target Rstest version:
+- If coverage is enabled, add a Rstest provider supported by the target Rstest version and environment:
   - `coverage.provider: 'istanbul'` -> `@rstest/coverage-istanbul`
-  - `coverage.provider: 'v8'` -> `@rstest/coverage-v8` only for Rstest >= 0.10.2; for Rstest 0.8.x targets, use Istanbul or explicitly plan a toolchain upgrade first
+  - `coverage.provider: 'v8'` -> `@rstest/coverage-v8` only for Rstest >= 0.10.2 outside Browser Mode; for Browser Mode or Rstest 0.8.x targets, use Istanbul or explicitly plan a toolchain upgrade first
 - If migrating a project that already has `rslib.config.*`, prefer `@rstest/adapter-rslib`.
 - If migrating a project that already has `rsbuild.config.*`, prefer `@rstest/adapter-rsbuild`.
 - Keep Jest/Vitest packages until the migrated scope is green. Remove them only in the cleanup phase and only if no other scope still uses them.
@@ -48,6 +48,7 @@ Before debugging test failures, check whether the Rstest target version matches 
 
 - Latest Rstest uses the Rsbuild/Rspack 2.x ecosystem.
 - Rstest 0.8.x uses the Rsbuild/Rspack 1.x ecosystem.
+- Latest Rstest also requires Node `^20.19.0 || >=22.12.0`; check `node -v` and `package.json#engines` before selecting it. If the project is pinned to an older Node version, ask for a Node upgrade or choose a compatible Rstest line instead.
 - `@rsbuild/plugin-*` packages must satisfy the installed `@rsbuild/core` peer range. Do not force major equality for plugins whose published peer range intentionally spans majors.
 - Choose adapters such as `@rstest/adapter-rsbuild`, `@rstest/adapter-rslib`, and `@rstest/adapter-rspack` by peer compatibility with `@rstest/core` and the underlying Rsbuild/Rslib/Rspack version. Rstest 0.8.x migrations may need older adapter package versions whose package major does not match `@rstest/core`.
 - In monorepos, check root and package-level `overrides`, `resolutions`, `pnpm.overrides`, lockfile entries, and nested package managers for duplicate major versions.

--- a/skills/migrate-to-rstest/references/dependency-install-gate.md
+++ b/skills/migrate-to-rstest/references/dependency-install-gate.md
@@ -4,87 +4,30 @@ Use this reference when running the dependency install gate step of the migratio
 
 ## Quick path
 
-Use the repository's native package manager instead of adding another package just to detect the manager.
+Use the repo's native package manager; do not add a detector package. Pick it from `packageManager`, then lock files (`pnpm-lock.yaml`, `yarn.lock`, `package-lock.json`, `npm-shrinkwrap.json`, `bun.lock`, `bun.lockb`), then CI/workspace hints.
 
-Detect the manager from existing project signals, in this order:
-
-1. `package.json#packageManager`
-2. Lockfile: `pnpm-lock.yaml`, `yarn.lock`, `package-lock.json`, `npm-shrinkwrap.json`, `bun.lock`, or `bun.lockb`
-3. Existing CI/test scripts or workspace files such as `pnpm-workspace.yaml` or `.yarnrc.yml`
-
-Then install with that manager. For example, in a pnpm repo:
-
-```bash
-pnpm install
-```
-
-After adding `@rstest/core`, verify Rstest through the same local manager path without remote package fallback. For example:
-
-```bash
-pnpm exec rstest -h
-```
-
-For npm-only repos, run `./node_modules/.bin/rstest -h` directly so the check cannot fall back to a remote package. In Yarn/Bun repos, use the repo's local binary execution path only when it resolves the installed dependency.
-
-If a package manager script already exists after the script migration, also prefer the repo-native script (for example `pnpm test -- --help` only when that is how the repo runs tests).
+After adding `@rstest/core`, verify through a local-only path: e.g. `pnpm exec rstest -h`, a migrated test script, or `./node_modules/.bin/rstest -h` for npm-only repos. Avoid commands that can fetch a remote `rstest` package.
 
 ## Dependency decisions
 
-Install only packages the migrated scope needs:
+Install only what the migrated scope needs: `@rstest/core`, one capability-supported coverage provider if coverage is enabled, and an adapter only when the existing Rsbuild/Rslib/Rspack config and peer ranges support it.
 
-- Always add `@rstest/core` as a dev dependency for a migrated scope.
-- If coverage is enabled, add a Rstest provider supported by the target Rstest version and environment:
-  - `coverage.provider: 'istanbul'` -> `@rstest/coverage-istanbul`
-  - `coverage.provider: 'v8'` -> `@rstest/coverage-v8` only for Rstest >= 0.10.2 outside Browser Mode; for Browser Mode or Rstest 0.8.x targets, use Istanbul or explicitly plan a toolchain upgrade first
-- If migrating a project that already has `rslib.config.*`, prefer `@rstest/adapter-rslib`.
-- If migrating a project that already has `rsbuild.config.*`, prefer `@rstest/adapter-rsbuild`.
-- Keep Jest/Vitest packages until the migrated scope is green. Remove them only in the cleanup phase and only if no other scope still uses them.
+Keep Jest/Vitest and legacy coverage packages until the migrated scope is green. Remove them only during cleanup and only if no other scope still uses them. Do not add multiple Rstest coverage providers for one final scope unless the repo intentionally keeps multiple coverage modes.
 
-Temporary overlap between legacy coverage packages and Rstest coverage packages is acceptable until the migrated scope is green. Do not add multiple Rstest coverage providers for the same final scope unless the repo intentionally keeps multiple coverage modes.
+## Version and capability gate
 
-## Rsbuild/Rspack version compatibility gate
+Before debugging test failures, choose a compatible Rstest line and avoid latest-only config on older targets:
 
-Before debugging test failures, check whether the Rstest target version matches the installed Rstack toolchain:
+- Latest Rstest needs Node `^20.19.0 || >=22.12.0` and the Rsbuild/Rspack 2.x ecosystem. For Rsbuild/Rspack 1.x or older Node projects, use a compatible older line such as Rstest 0.8.x unless the user accepts a toolchain upgrade.
+- If the target line lacks a needed feature, either use the fallback or ask whether to upgrade first.
+- Prefer config-level fallbacks on older targets: plain project objects, `output.externals`/aliases/manual config, Istanbul coverage, config/projects for env splits, explicit/manual mocks, config `pool.maxWorkers`, or manual Rspack config.
+- Treat `defineInlineProject`, `output.bundleDependencies`, `detectAsyncLeaks`, V8 coverage, file-level env comments, newer mock helpers, CLI `--pool.maxWorkers`, and `@rstest/adapter-rspack` as latest-line features unless target docs/types prove support.
+- Choose Rsbuild plugins and Rstest adapters by peer dependency compatibility, not package-name major equality. In monorepos, check root and package-level overrides/resolutions, lockfile entries, and nested package managers for duplicate majors.
 
-- Latest Rstest uses the Rsbuild/Rspack 2.x ecosystem.
-- Rstest 0.8.x uses the Rsbuild/Rspack 1.x ecosystem.
-- Latest Rstest also requires Node `^20.19.0 || >=22.12.0`; check `node -v` and `package.json#engines` before selecting it. If the project is pinned to an older Node version, ask for a Node upgrade or choose a compatible Rstest line instead.
-- `@rsbuild/plugin-*` packages must satisfy the installed `@rsbuild/core` peer range. Do not force major equality for plugins whose published peer range intentionally spans majors.
-- Choose adapters such as `@rstest/adapter-rsbuild`, `@rstest/adapter-rslib`, and `@rstest/adapter-rspack` by peer compatibility with `@rstest/core` and the underlying Rsbuild/Rslib/Rspack version. Rstest 0.8.x migrations may need older adapter package versions whose package major does not match `@rstest/core`.
-- In monorepos, check root and package-level `overrides`, `resolutions`, `pnpm.overrides`, lockfile entries, and nested package managers for duplicate major versions.
-
-Use the repo-native package manager for inspection. Examples:
-
-```bash
-pnpm -r list @rstest/core @rsbuild/core @rspack/core @rslib/core --depth Infinity
-pnpm -r list @rstest/adapter-rsbuild @rstest/adapter-rslib @rstest/adapter-rspack --depth Infinity
-pnpm -r list --depth Infinity | rg '@rsbuild/plugin-'
-```
-
-For npm-only repos, use `npm ls` instead:
-
-```bash
-npm ls @rstest/core @rsbuild/core @rspack/core @rslib/core 2>/dev/null || true
-npm ls --all 2>/dev/null | grep '@rsbuild/plugin-' || true
-```
-
-If errors mention Rsbuild/Rspack config schema, plugin hooks, compiler instance mismatch, missing plugin APIs, or peer dependency conflicts, fix dependency versions first. Do not rewrite tests to hide a toolchain-major mismatch.
+Inspect with the repo-native manager across workspaces (for example `pnpm -r list ... --depth Infinity`, or `npm ls --all` plus filtering). If errors mention config schema, plugin hooks, compiler mismatch, missing plugin APIs, or peer conflicts, fix dependency versions first; do not rewrite tests to hide toolchain skew.
 
 ## Blocked mode
 
-If install/check fails:
+If install/check fails, stop broad edits. Do not mix package managers or fake a migration without a runnable local `rstest` binary unless the user accepts a config-only patch.
 
-- Stop broad migration edits.
-- Use the repo-native package manager indicated by `packageManager`, lock files, workspace files, or existing scripts.
-- Do not mix multiple package managers in one attempt unless user asks.
-- In monorepos, run installs/checks from the workspace root unless the repo clearly uses nested package managers.
-- Do not fake a migration by editing code without a runnable `rstest` binary unless the user explicitly accepts a config-only patch.
-
-Return a blocker report with:
-
-1. Exact failed command(s).
-2. Error class (network/auth/registry/peer conflict/lockfile mismatch/permission).
-3. Concrete next command(s) for the user to run.
-4. Whether files were already changed.
-5. Resume point: "after dependencies are installed, continue from the deltas step".
-6. Install strategy used and which repo signal selected it (`packageManager`, lockfile, workspace file, or existing script).
+Report the failed command, error class, chosen package-manager signal, files already changed, next command, and resume point.

--- a/skills/migrate-to-rstest/references/dependency-install-gate.md
+++ b/skills/migrate-to-rstest/references/dependency-install-gate.md
@@ -10,9 +10,54 @@ Run install with `ni` and trust its workspace/package-manager detection:
 npx -y @antfu/ni install
 ```
 
-Then verify `rstest` is resolvable from local dependencies.
+Then verify Rstest is resolvable from local dependencies:
 
-If this succeeds, continue migration.
+```bash
+npx rstest -h
+```
+
+If a package manager script already exists after the script migration, also prefer the repo-native script (for example `pnpm test -- --help` only when that is how the repo runs tests).
+
+## Dependency decisions
+
+Install only packages the migrated scope needs:
+
+- Always add `@rstest/core` as a dev dependency for a migrated scope.
+- If coverage is enabled, add the matching provider package:
+  - `coverage.provider: 'istanbul'` -> `@rstest/coverage-istanbul`
+  - `coverage.provider: 'v8'` -> `@rstest/coverage-v8`
+- If migrating a project that already has `rslib.config.*`, prefer `@rstest/adapter-rslib`.
+- If migrating a project that already has `rsbuild.config.*`, prefer `@rstest/adapter-rsbuild`.
+- Keep Jest/Vitest packages until the migrated scope is green. Remove them only in the cleanup phase and only if no other scope still uses them.
+
+Do not add both old and new coverage providers for the same scope unless mixed-mode scopes still require both.
+
+## Rsbuild/Rspack version compatibility gate
+
+Before debugging test failures, check whether the Rstest target version matches the installed Rstack toolchain:
+
+- Latest Rstest uses the Rsbuild/Rspack 2.x ecosystem.
+- Rstest 0.8.x uses the Rsbuild/Rspack 1.x ecosystem.
+- `@rsbuild/plugin-*` packages must match the `@rsbuild/core` major version.
+- Adapters such as `@rstest/adapter-rsbuild`, `@rstest/adapter-rslib`, and `@rstest/adapter-rspack` should match `@rstest/core`.
+- In monorepos, check root and package-level `overrides`, `resolutions`, `pnpm.overrides`, lockfile entries, and nested package managers for duplicate major versions.
+
+Use the repo-native package manager for inspection. Examples:
+
+```bash
+pnpm why @rstest/core @rsbuild/core @rspack/core @rslib/core
+pnpm why @rstest/adapter-rsbuild @rstest/adapter-rslib @rstest/adapter-rspack
+pnpm why '@rsbuild/plugin-*'
+```
+
+For npm-only repos, use `npm ls` instead:
+
+```bash
+npm ls @rstest/core @rsbuild/core @rspack/core @rslib/core 2>/dev/null || true
+npm ls '@rsbuild/plugin-*' 2>/dev/null || true
+```
+
+If errors mention Rsbuild/Rspack config schema, plugin hooks, compiler instance mismatch, missing plugin APIs, or peer dependency conflicts, fix dependency versions first. Do not rewrite tests to hide a toolchain-major mismatch.
 
 ## Blocked mode
 
@@ -22,6 +67,7 @@ If install/check fails:
 - If `ni` is unavailable or environment-blocked, use the repo-native package manager as fallback.
 - Do not mix multiple package managers in one attempt unless user asks.
 - In monorepo, only do manual workspace/root fallback when `ni` cannot be used.
+- Do not fake a migration by editing code without a runnable `rstest` binary unless the user explicitly accepts a config-only patch.
 
 Return a blocker report with:
 

--- a/skills/migrate-to-rstest/references/dependency-install-gate.md
+++ b/skills/migrate-to-rstest/references/dependency-install-gate.md
@@ -24,7 +24,7 @@ After adding `@rstest/core`, verify Rstest through the same local manager path w
 pnpm exec rstest -h
 ```
 
-For npm-only repos, use `npm exec --no -- rstest -h` after local install, or run `./node_modules/.bin/rstest -h` directly. For Yarn/Bun repos, use the repo's local binary execution path only when it resolves the installed dependency.
+For npm-only repos, run `./node_modules/.bin/rstest -h` directly, or use `npm exec -- rstest -h` after local install. In Yarn/Bun repos, use the repo's local binary execution path only when it resolves the installed dependency.
 
 If a package manager script already exists after the script migration, also prefer the repo-native script (for example `pnpm test -- --help` only when that is how the repo runs tests).
 

--- a/skills/migrate-to-rstest/references/dependency-install-gate.md
+++ b/skills/migrate-to-rstest/references/dependency-install-gate.md
@@ -10,11 +10,13 @@ Run install with `ni` and trust its workspace/package-manager detection:
 npx -y @antfu/ni install
 ```
 
-Then verify Rstest is resolvable from local dependencies:
+Then verify Rstest is resolvable from local dependencies without falling back to remote package execution:
 
 ```bash
-npx rstest -h
+pnpm exec rstest -h
 ```
+
+For npm-only repos, use `npm exec --no -- rstest -h` only after `@rstest/core` is installed locally, or run `./node_modules/.bin/rstest -h` directly.
 
 If a package manager script already exists after the script migration, also prefer the repo-native script (for example `pnpm test -- --help` only when that is how the repo runs tests).
 
@@ -38,8 +40,8 @@ Before debugging test failures, check whether the Rstest target version matches 
 
 - Latest Rstest uses the Rsbuild/Rspack 2.x ecosystem.
 - Rstest 0.8.x uses the Rsbuild/Rspack 1.x ecosystem.
-- `@rsbuild/plugin-*` packages must match the `@rsbuild/core` major version.
-- Adapters such as `@rstest/adapter-rsbuild`, `@rstest/adapter-rslib`, and `@rstest/adapter-rspack` should match `@rstest/core`.
+- `@rsbuild/plugin-*` packages must satisfy the installed `@rsbuild/core` peer range. Do not force major equality for plugins whose published peer range intentionally spans majors.
+- Choose adapters such as `@rstest/adapter-rsbuild`, `@rstest/adapter-rslib`, and `@rstest/adapter-rspack` by peer compatibility with `@rstest/core` and the underlying Rsbuild/Rslib/Rspack version. Rstest 0.8.x migrations may need older adapter package versions whose package major does not match `@rstest/core`.
 - In monorepos, check root and package-level `overrides`, `resolutions`, `pnpm.overrides`, lockfile entries, and nested package managers for duplicate major versions.
 
 Use the repo-native package manager for inspection. Examples:
@@ -47,14 +49,14 @@ Use the repo-native package manager for inspection. Examples:
 ```bash
 pnpm why @rstest/core @rsbuild/core @rspack/core @rslib/core
 pnpm why @rstest/adapter-rsbuild @rstest/adapter-rslib @rstest/adapter-rspack
-pnpm why '@rsbuild/plugin-*'
+pnpm ls --depth Infinity | rg '@rsbuild/plugin-'
 ```
 
 For npm-only repos, use `npm ls` instead:
 
 ```bash
 npm ls @rstest/core @rsbuild/core @rspack/core @rslib/core 2>/dev/null || true
-npm ls '@rsbuild/plugin-*' 2>/dev/null || true
+npm ls --all 2>/dev/null | grep '@rsbuild/plugin-' || true
 ```
 
 If errors mention Rsbuild/Rspack config schema, plugin hooks, compiler instance mismatch, missing plugin APIs, or peer dependency conflicts, fix dependency versions first. Do not rewrite tests to hide a toolchain-major mismatch.

--- a/skills/migrate-to-rstest/references/dependency-install-gate.md
+++ b/skills/migrate-to-rstest/references/dependency-install-gate.md
@@ -4,19 +4,27 @@ Use this reference when running the dependency install gate step of the migratio
 
 ## Quick path
 
-Run install with `ni` and trust its workspace/package-manager detection:
+Use the repository's native package manager instead of adding another package just to detect the manager.
+
+Detect the manager from existing project signals, in this order:
+
+1. `package.json#packageManager`
+2. Lockfile: `pnpm-lock.yaml`, `yarn.lock`, `package-lock.json`, `npm-shrinkwrap.json`, or `bun.lockb`
+3. Existing CI/test scripts or workspace files such as `pnpm-workspace.yaml` or `.yarnrc.yml`
+
+Then install with that manager. For example, in a pnpm repo:
 
 ```bash
-npx -y @antfu/ni install
+pnpm install
 ```
 
-Then verify Rstest is resolvable from local dependencies without falling back to remote package execution:
+After adding `@rstest/core`, verify Rstest through the same local manager path without remote package fallback. For example:
 
 ```bash
 pnpm exec rstest -h
 ```
 
-For npm-only repos, use `npm exec --no -- rstest -h` only after `@rstest/core` is installed locally, or run `./node_modules/.bin/rstest -h` directly.
+For npm-only repos, use `npm exec --no -- rstest -h` after local install, or run `./node_modules/.bin/rstest -h` directly. For Yarn/Bun repos, use the repo's local binary execution path only when it resolves the installed dependency.
 
 If a package manager script already exists after the script migration, also prefer the repo-native script (for example `pnpm test -- --help` only when that is how the repo runs tests).
 
@@ -25,14 +33,14 @@ If a package manager script already exists after the script migration, also pref
 Install only packages the migrated scope needs:
 
 - Always add `@rstest/core` as a dev dependency for a migrated scope.
-- If coverage is enabled, add the matching provider package:
+- If coverage is enabled, add a Rstest provider supported by the target Rstest version:
   - `coverage.provider: 'istanbul'` -> `@rstest/coverage-istanbul`
-  - `coverage.provider: 'v8'` -> `@rstest/coverage-v8`
+  - `coverage.provider: 'v8'` -> `@rstest/coverage-v8` only for Rstest >= 0.10.2; for Rstest 0.8.x targets, use Istanbul or explicitly plan a toolchain upgrade first
 - If migrating a project that already has `rslib.config.*`, prefer `@rstest/adapter-rslib`.
 - If migrating a project that already has `rsbuild.config.*`, prefer `@rstest/adapter-rsbuild`.
 - Keep Jest/Vitest packages until the migrated scope is green. Remove them only in the cleanup phase and only if no other scope still uses them.
 
-Do not add both old and new coverage providers for the same scope unless mixed-mode scopes still require both.
+Temporary overlap between legacy coverage packages and Rstest coverage packages is acceptable until the migrated scope is green. Do not add multiple Rstest coverage providers for the same final scope unless the repo intentionally keeps multiple coverage modes.
 
 ## Rsbuild/Rspack version compatibility gate
 
@@ -47,9 +55,9 @@ Before debugging test failures, check whether the Rstest target version matches 
 Use the repo-native package manager for inspection. Examples:
 
 ```bash
-pnpm why @rstest/core @rsbuild/core @rspack/core @rslib/core
-pnpm why @rstest/adapter-rsbuild @rstest/adapter-rslib @rstest/adapter-rspack
-pnpm ls --depth Infinity | rg '@rsbuild/plugin-'
+pnpm -r list @rstest/core @rsbuild/core @rspack/core @rslib/core --depth Infinity
+pnpm -r list @rstest/adapter-rsbuild @rstest/adapter-rslib @rstest/adapter-rspack --depth Infinity
+pnpm -r list --depth Infinity | rg '@rsbuild/plugin-'
 ```
 
 For npm-only repos, use `npm ls` instead:
@@ -66,9 +74,9 @@ If errors mention Rsbuild/Rspack config schema, plugin hooks, compiler instance 
 If install/check fails:
 
 - Stop broad migration edits.
-- If `ni` is unavailable or environment-blocked, use the repo-native package manager as fallback.
+- Use the repo-native package manager indicated by `packageManager`, lockfiles, workspace files, or existing scripts.
 - Do not mix multiple package managers in one attempt unless user asks.
-- In monorepo, only do manual workspace/root fallback when `ni` cannot be used.
+- In monorepos, run installs/checks from the workspace root unless the repo clearly uses nested package managers.
 - Do not fake a migration by editing code without a runnable `rstest` binary unless the user explicitly accepts a config-only patch.
 
 Return a blocker report with:
@@ -78,4 +86,4 @@ Return a blocker report with:
 3. Concrete next command(s) for the user to run.
 4. Whether files were already changed.
 5. Resume point: "after dependencies are installed, continue from the deltas step".
-6. Install strategy used (`ni` or explicit manager fallback).
+6. Install strategy used and which repo signal selected it (`packageManager`, lockfile, workspace file, or existing script).

--- a/skills/migrate-to-rstest/references/dependency-install-gate.md
+++ b/skills/migrate-to-rstest/references/dependency-install-gate.md
@@ -74,7 +74,7 @@ If errors mention Rsbuild/Rspack config schema, plugin hooks, compiler instance 
 If install/check fails:
 
 - Stop broad migration edits.
-- Use the repo-native package manager indicated by `packageManager`, lockfiles, workspace files, or existing scripts.
+- Use the repo-native package manager indicated by `packageManager`, lock files, workspace files, or existing scripts.
 - Do not mix multiple package managers in one attempt unless user asks.
 - In monorepos, run installs/checks from the workspace root unless the repo clearly uses nested package managers.
 - Do not fake a migration by editing code without a runnable `rstest` binary unless the user explicitly accepts a config-only patch.

--- a/skills/migrate-to-rstest/references/detect-test-framework.md
+++ b/skills/migrate-to-rstest/references/detect-test-framework.md
@@ -25,12 +25,9 @@ Use this reference to decide the migration path and scope.
 
 ### Rstack integration signals
 
-- `rslib.config.*` exists -> consider `@rstest/adapter-rslib` and `extends: withRslibConfig()`.
-- `rsbuild.config.*` exists -> consider `@rstest/adapter-rsbuild` and `extends: withRsbuildConfig()`.
-- `rspack.config.*` exists -> for Rspack 2.x, consider `@rstest/adapter-rspack` and `extends: withRspackConfig()`; for Rspack 1.x / Rstest 0.8.x, prefer a manual Rstest config that ports the necessary Rspack settings instead of installing the Rspack adapter.
-- `@rsbuild/core`, `@rspack/core`, `@rslib/core`, or `@rsbuild/plugin-*` in dependencies/devDependencies indicates the migration must preserve Rstack toolchain compatibility.
-- `overrides`, `resolutions`, and `pnpm.overrides` can pin Rsbuild/Rspack or plugin majors; inspect them before choosing the Rstest target version.
-- Existing Rspack/Rsbuild aliases, plugins, `source.define`, `tools.swc`, or `output.externals` are often better migrated through adapters/config than by editing tests.
+- Existing `rslib.config.*`, `rsbuild.config.*`, or Rspack/Rsbuild aliases/plugins usually means adapters or config ports should be tried before test edits.
+- `rspack.config.*` can use `@rstest/adapter-rspack` only on a compatible Rspack 2.x line; for Rspack 1.x / Rstest 0.8.x, port needed settings manually.
+- `@rsbuild/core`, `@rspack/core`, `@rslib/core`, `@rsbuild/plugin-*`, `overrides`, `resolutions`, or `pnpm.overrides` must feed into the dependency gate before choosing Rstest/adapters/plugins.
 
 ### Browser / DOM signals
 
@@ -44,6 +41,6 @@ Use this reference to decide the migration path and scope.
 - If both are detected, treat as mixed mode and migrate one scope at a time (package/suite/project).
 - Prefer migrating the currently CI-critical or higher-failure scope first.
 - Keep both legacy runners until each migrated scope is green on Rstest.
-- Choose the Rstest target version together with the Rstack toolchain major: latest Rstest for Rsbuild/Rspack 2.x, or Rstest 0.8.x for Rsbuild/Rspack 1.x. Check each `@rsbuild/plugin-*` package peer range before changing plugin versions.
+- Choose the Rstest target line with the dependency gate before changing adapter/plugin versions.
 - In monorepos, choose the smallest runnable scope that has its own package/config/test script. Do not migrate unrelated packages just because they share a root lockfile.
 - If the root config is only a project/workspace aggregator, preserve that role: Rstest root `projects` config is not itself a test project unless the root is explicitly included as a project.

--- a/skills/migrate-to-rstest/references/detect-test-framework.md
+++ b/skills/migrate-to-rstest/references/detect-test-framework.md
@@ -1,6 +1,6 @@
 # Detect Test Framework
 
-Use this reference to decide the migration path when detecting the current test framework.
+Use this reference to decide the migration path and scope.
 
 ## Detection signals
 
@@ -8,21 +8,42 @@ Use this reference to decide the migration path when detecting the current test 
 
 - `jest` in `dependencies` or `devDependencies`
 - `jest.config.*` exists
-- `package.json` contains `jest` config
+- `package.json` contains a `jest` config block
 - test scripts use `jest`
-- test code uses `@jest/globals` or `jest.` APIs
+- test code imports from `@jest/globals` or uses `jest.` APIs
+- Jest-only packages such as `ts-jest`, `babel-jest`, `jest-environment-jsdom`, `identity-obj-proxy`, `@types/jest`, `jest-junit`
 
 ### Vitest signals
 
 - `vitest` in `dependencies` or `devDependencies`
 - `vitest.config.*` exists
 - `vite.config.*` contains a `test` block for Vitest
-- test scripts use `vitest`
-- test code imports from `vitest` (`vi`, `describe`, `it`, `expect`)
+- `vitest.workspace.*` exists
+- test scripts use `vitest`, `vitest run`, or `vitest --run`
+- test code imports from `vitest` (`vi`, `vitest`, `describe`, `it`, `expect`)
+- Vitest-only packages such as `@vitest/coverage-v8`, `@vitest/coverage-istanbul`, `@vitest/ui`
+
+### Rstack integration signals
+
+- `rslib.config.*` exists -> consider `@rstest/adapter-rslib` and `extends: withRslibConfig()`.
+- `rsbuild.config.*` exists -> consider `@rstest/adapter-rsbuild` and `extends: withRsbuildConfig()`.
+- `rspack.config.*` exists -> consider `@rstest/adapter-rspack` and `extends: withRspackConfig()`.
+- `@rsbuild/core`, `@rspack/core`, `@rslib/core`, or `@rsbuild/plugin-*` in dependencies/devDependencies indicates the migration must preserve Rstack toolchain compatibility.
+- `overrides`, `resolutions`, and `pnpm.overrides` can pin Rsbuild/Rspack or plugin majors; inspect them before choosing the Rstest target version.
+- Existing Rspack/Rsbuild aliases, plugins, `source.define`, `tools.swc`, or `output.externals` are often better migrated through adapters/config than by editing tests.
+
+### Browser / DOM signals
+
+- Jest `testEnvironment: 'jsdom'`, Vitest `environment: 'jsdom'` / `happy-dom`, or file-level environment comments.
+- React/Vue Testing Library setup files.
+- `@testing-library/jest-dom/vitest` should be replaced with direct matcher registration in Rstest setup.
 
 ## Decision rules
 
 - If only one runner is detected, migrate that runner path.
-- If both are detected, treat as mixed mode and migrate one scope at a time (package/suite).
+- If both are detected, treat as mixed mode and migrate one scope at a time (package/suite/project).
 - Prefer migrating the currently CI-critical or higher-failure scope first.
 - Keep both legacy runners until each migrated scope is green on Rstest.
+- Choose the Rstest target version together with the Rstack toolchain major: latest Rstest for Rsbuild/Rspack 2.x, or Rstest 0.8.x for Rsbuild/Rspack 1.x. Align `@rsbuild/plugin-*` with the same Rsbuild major before config migration.
+- In monorepos, choose the smallest runnable scope that has its own package/config/test script. Do not migrate unrelated packages just because they share a root lockfile.
+- If the root config is only a project/workspace aggregator, preserve that role: Rstest root `projects` config is not itself a test project unless the root is explicitly included as a project.

--- a/skills/migrate-to-rstest/references/detect-test-framework.md
+++ b/skills/migrate-to-rstest/references/detect-test-framework.md
@@ -27,7 +27,7 @@ Use this reference to decide the migration path and scope.
 
 - `rslib.config.*` exists -> consider `@rstest/adapter-rslib` and `extends: withRslibConfig()`.
 - `rsbuild.config.*` exists -> consider `@rstest/adapter-rsbuild` and `extends: withRsbuildConfig()`.
-- `rspack.config.*` exists -> consider `@rstest/adapter-rspack` and `extends: withRspackConfig()`.
+- `rspack.config.*` exists -> for Rspack 2.x, consider `@rstest/adapter-rspack` and `extends: withRspackConfig()`; for Rspack 1.x / Rstest 0.8.x, prefer a manual Rstest config that ports the necessary Rspack settings instead of installing the Rspack adapter.
 - `@rsbuild/core`, `@rspack/core`, `@rslib/core`, or `@rsbuild/plugin-*` in dependencies/devDependencies indicates the migration must preserve Rstack toolchain compatibility.
 - `overrides`, `resolutions`, and `pnpm.overrides` can pin Rsbuild/Rspack or plugin majors; inspect them before choosing the Rstest target version.
 - Existing Rspack/Rsbuild aliases, plugins, `source.define`, `tools.swc`, or `output.externals` are often better migrated through adapters/config than by editing tests.
@@ -44,6 +44,6 @@ Use this reference to decide the migration path and scope.
 - If both are detected, treat as mixed mode and migrate one scope at a time (package/suite/project).
 - Prefer migrating the currently CI-critical or higher-failure scope first.
 - Keep both legacy runners until each migrated scope is green on Rstest.
-- Choose the Rstest target version together with the Rstack toolchain major: latest Rstest for Rsbuild/Rspack 2.x, or Rstest 0.8.x for Rsbuild/Rspack 1.x. Align `@rsbuild/plugin-*` with the same Rsbuild major before config migration.
+- Choose the Rstest target version together with the Rstack toolchain major: latest Rstest for Rsbuild/Rspack 2.x, or Rstest 0.8.x for Rsbuild/Rspack 1.x. Check each `@rsbuild/plugin-*` package peer range before changing plugin versions.
 - In monorepos, choose the smallest runnable scope that has its own package/config/test script. Do not migrate unrelated packages just because they share a root lockfile.
 - If the root config is only a project/workspace aggregator, preserve that role: Rstest root `projects` config is not itself a test project unless the root is explicitly included as a project.

--- a/skills/migrate-to-rstest/references/global-api-migration.md
+++ b/skills/migrate-to-rstest/references/global-api-migration.md
@@ -11,10 +11,8 @@ The rules below are skill-side enforcement on top of that mapping.
 
 ## Mapping policy
 
-- Prefer imported APIs when a file already imports test APIs: `import { describe, expect, it, test, rs } from '@rstest/core'`.
-- If preserving global-style tests, set `globals: true` and add `@rstest/core/globals` to TypeScript types.
-- Rstest global APIs include `test`, `describe`, `it`, `expect`, `assert`, hooks, `onTestFinished`, `onTestFailed`, `rs`, and `rstest`.
-- `rs` and `rstest` are equivalent runtime utility aliases. Prefer `rs` for consistency with Rstest migration docs.
+- Prefer imports from `@rstest/core`; use globals only when preserving global-style tests (`globals: true` plus `@rstest/core/globals` types).
+- Rstest globals include test APIs, hooks, `rs`, and `rstest`. Prefer `rs` for migration consistency.
 
 ## Red lines
 

--- a/skills/migrate-to-rstest/references/global-api-migration.md
+++ b/skills/migrate-to-rstest/references/global-api-migration.md
@@ -2,22 +2,48 @@
 
 Use this reference when tests rely on globally available test APIs (Jest's `jest.<api>`, or Vitest's `vi.<api>` / `vitest.<api>` under `globals: true`).
 
-For the identifier mapping (`jest.` / `vi.` / `vitest.` → Rstest equivalents), see the official guides:
+For identifier mapping (`jest.` / `vi.` / `vitest.` -> Rstest equivalents), see the official guides:
 
 - Jest: https://rstest.rs/guide/migration/jest.md (see "Test API")
 - Vitest: https://rstest.rs/guide/migration/vitest.md (see "Test API" and "Global APIs")
 
 The rules below are skill-side enforcement on top of that mapping.
 
+## Mapping policy
+
+- Prefer imported APIs when a file already imports test APIs: `import { describe, expect, it, test, rs } from '@rstest/core'`.
+- If preserving global-style tests, set `globals: true` and add `@rstest/core/globals` to TypeScript types.
+- Rstest global APIs include `test`, `describe`, `it`, `expect`, `assert`, hooks, `onTestFinished`, `onTestFailed`, `rs`, and `rstest`.
+- `rs` and `rstest` are equivalent runtime utility aliases. Prefer `rs` for consistency with Rstest migration docs.
+
 ## Red lines
 
-1. **No shims.** All three forms below leave the migration incomplete and must be rejected in every test and setup file:
+1. **No shims.** All forms below leave the migration incomplete and must be rejected in every test and setup file:
    - `globalThis.vi = rs;` / `global.jest = rs;` (direct global aliasing)
    - `const vi = rs;` / `const jest = rs;` (local rebinding)
    - `import { rs as vi } from '@rstest/core';` / `import { rs as jest } from '@rstest/core';` (aliased named import)
 
-   Fix at every call site instead. Do not propose a shim "just to keep the diff small" — it hides whether the migration actually happened, blocks IDE refactors, and silences future deprecation warnings.
+   Fix at every call site instead. Do not propose a shim "just to keep the diff small" - it hides whether the migration actually happened, blocks IDE refactors, and silences future deprecation warnings.
 
-2. **No test-name mutation.** When rewriting `vi.` / `jest.` / `vitest.`, only replace identifiers that precede a `(`. After every batch edit, grep `describe\(|it\(|test\(` to confirm no name string was rewritten — test names are stable identifiers, not labels for the new API.
+2. **No test-name mutation.** When rewriting `vi.` / `jest.` / `vitest.`, only replace identifiers that precede a property access and eventual call expression. After every batch edit, grep test declarations to confirm no name string was rewritten:
 
-3. **Global-only scope.** Do not apply these replacements to import-style APIs; this rule is global-only.
+```bash
+rg -n "(describe|it|test)\\(" --glob '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}'
+```
+
+Test names are stable identifiers, not labels for the new API.
+
+3. **No mixed local aliases.** Avoid mixing `vi` and `rs`, or `jest` and `rs`, in the same migrated file. If you touch a file, migrate all framework utility calls in that file.
+
+## Safer replacement workflow
+
+1. Search first:
+
+```bash
+rg -n "\\b(vi|vitest|jest)\\s*\\." --glob '*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}'
+```
+
+2. Replace only code identifiers, not arbitrary strings or snapshots.
+3. Update imports from `vitest` / `@jest/globals` to `@rstest/core` as needed.
+4. Run the search again; the only acceptable leftovers are comments documenting the migration or untouched legacy scopes.
+5. If `globals: true` remains, verify TypeScript sees `@rstest/core/globals`.

--- a/skills/migrate-to-rstest/references/jest-migration-deltas.md
+++ b/skills/migrate-to-rstest/references/jest-migration-deltas.md
@@ -26,8 +26,8 @@ When local docs are available, prefer the checked-out source, for example `websi
 ## Version compatibility
 
 - Latest Rstest uses Rsbuild/Rspack 2.x; Rstest 0.8.x uses Rsbuild/Rspack 1.x.
-- If replacing `babel-jest`, `ts-jest`, or custom transformers with Rsbuild plugins such as `@rsbuild/plugin-babel`, choose plugin majors that match `@rsbuild/core`.
-- Keep `@rstest/adapter-*` aligned with `@rstest/core`. Treat Rsbuild/Rspack/plugin schema or peer errors as dependency skew first, not test failures.
+- If replacing `babel-jest`, `ts-jest`, or custom transformers with Rsbuild plugins such as `@rsbuild/plugin-babel`, choose plugin versions that satisfy the installed `@rsbuild/core` peer range.
+- Choose `@rstest/adapter-*` versions by peer compatibility with `@rstest/core` and the underlying Rsbuild/Rslib/Rspack version. Treat Rsbuild/Rspack/plugin schema or peer errors as dependency skew first, not test failures.
 
 ## Jest-specific enforcement
 

--- a/skills/migrate-to-rstest/references/jest-migration-deltas.md
+++ b/skills/migrate-to-rstest/references/jest-migration-deltas.md
@@ -12,22 +12,16 @@ When local docs are available, prefer the checked-out source, for example `websi
 
 ## High-signal deltas
 
-- Scripts: `jest` -> `rstest`; `--watch` / `--watchAll` -> `rstest --watch`; `--runInBand` -> `--pool.maxWorkers 1`; Jest `-w` means workers, but Rstest `-w` means watch.
+- Scripts: `jest` -> `rstest`; `--watch` / `--watchAll` -> `rstest --watch`; `--runInBand` -> `--pool.maxWorkers 1` only when supported, otherwise config `pool.maxWorkers: 1`; Jest `-w` means workers, but Rstest `-w` means watch.
 - Config: create `rstest.config.ts` with `defineConfig` from `@rstest/core`. Map every important Jest field through the official guide; do not silently drop unknown fields.
-- Transforms: remove `preset`, `ts-jest`, and most `transform` config where possible. Rstest uses SWC by default; use `tools.swc`, `output.bundleDependencies`, or an Rsbuild plugin only when the project needs custom behavior.
+- Transforms: remove `preset`, `ts-jest`, and most `transform` config where possible. Rstest uses SWC by default; use version-supported SWC/output/Rsbuild plugin config only when needed.
 - Setup: merge Jest `setupFiles` and `setupFilesAfterEnv` into Rstest `setupFiles` because Rstest setup runs after framework registration.
 - Globals/APIs: `@jest/globals` -> `@rstest/core`; `jest.<api>` -> `rs.<api>`. If globals remain, set `globals: true` and add `@rstest/core/globals` types.
 - Async tests: `done` callback tests are unsupported; convert to Promise or `async` / `await`.
 - Hooks: `beforeEach` / `beforeAll` return values are cleanup functions in Rstest. Wrap setup-only arrow expressions in braces when needed.
-- Environment: `testEnvironmentOptions` becomes `testEnvironment: { name, options }`; file-level Jest environment comments are recognized during migration, but `@rstest-environment` is native.
+- Environment: `testEnvironmentOptions` becomes `testEnvironment: { name, options }`. File-level env comments are latest-only; older targets should split env-specific files into config/projects.
 - CJS mocking: use `rs.mockRequire()` for code paths using `require()`.
-- Coverage: install a Rstest provider supported by the target version. Jest `coverageProvider: 'babel'` maps to Rstest `istanbul`; Jest `coverageProvider: 'v8'` maps to Rstest `v8` with `@rstest/coverage-v8` only on Rstest >= 0.10.2. Use Istanbul for Rstest 0.8.x targets unless the user accepts a toolchain upgrade.
-
-## Version compatibility
-
-- Latest Rstest uses Rsbuild/Rspack 2.x; Rstest 0.8.x uses Rsbuild/Rspack 1.x.
-- If replacing `babel-jest`, `ts-jest`, or custom transformers with Rsbuild plugins such as `@rsbuild/plugin-babel`, choose plugin versions that satisfy the installed `@rsbuild/core` peer range.
-- Choose `@rstest/adapter-*` versions by peer compatibility with `@rstest/core` and the underlying Rsbuild/Rslib/Rspack version. Treat Rsbuild/Rspack/plugin schema or peer errors as dependency skew first, not test failures.
+- Coverage: install a Rstest provider supported by the target version. Jest `babel` maps to Istanbul; Jest `v8` maps to V8 only when the `dependency-install-gate.md` capability gate allows it.
 
 ## Jest-specific enforcement
 

--- a/skills/migrate-to-rstest/references/jest-migration-deltas.md
+++ b/skills/migrate-to-rstest/references/jest-migration-deltas.md
@@ -4,11 +4,33 @@ Use this reference when the current framework is Jest.
 
 ## Source of truth
 
-Follow the official migration guide for all Jest → Rstest field/API mapping (config table, CLI option mapping, snapshot format change, `done`/hooks/timeout differences, etc.):
+Use the official guide for exact field/API mappings:
 
 https://rstest.rs/guide/migration/jest.md
 
+When local docs are available, prefer the checked-out source, for example `website/docs/en/guide/migration/jest.mdx`.
+
+## High-signal deltas
+
+- Scripts: `jest` -> `rstest`; `--watch` / `--watchAll` -> `rstest --watch`; `--runInBand` -> `--pool.maxWorkers 1`; Jest `-w` means workers, but Rstest `-w` means watch.
+- Config: create `rstest.config.ts` with `defineConfig` from `@rstest/core`. Map every important Jest field through the official guide; do not silently drop unknown fields.
+- Transforms: remove `preset`, `ts-jest`, and most `transform` config where possible. Rstest uses SWC by default; use `tools.swc`, `output.bundleDependencies`, or an Rsbuild plugin only when the project needs custom behavior.
+- Setup: merge Jest `setupFiles` and `setupFilesAfterEnv` into Rstest `setupFiles` because Rstest setup runs after framework registration.
+- Globals/APIs: `@jest/globals` -> `@rstest/core`; `jest.<api>` -> `rs.<api>`. If globals remain, set `globals: true` and add `@rstest/core/globals` types.
+- Async tests: `done` callback tests are unsupported; convert to Promise or `async` / `await`.
+- Hooks: `beforeEach` / `beforeAll` return values are cleanup functions in Rstest. Wrap setup-only arrow expressions in braces when needed.
+- Environment: `testEnvironmentOptions` becomes `testEnvironment: { name, options }`; file-level Jest environment comments are recognized during migration, but `@rstest-environment` is native.
+- CJS mocking: use `rs.mockRequire()` for code paths using `require()`.
+- Coverage: install the matching Rstest provider; Jest `coverageProvider: 'babel'` maps to Rstest `istanbul`.
+
+## Version compatibility
+
+- Latest Rstest uses Rsbuild/Rspack 2.x; Rstest 0.8.x uses Rsbuild/Rspack 1.x.
+- If replacing `babel-jest`, `ts-jest`, or custom transformers with Rsbuild plugins such as `@rsbuild/plugin-babel`, choose plugin majors that match `@rsbuild/core`.
+- Keep `@rstest/adapter-*` aligned with `@rstest/core`. Treat Rsbuild/Rspack/plugin schema or peer errors as dependency skew first, not test failures.
+
 ## Jest-specific enforcement
 
-1. **Legacy file enumeration for phase (b) of SKILL principle 6.** Scope-local legacy files to delete once the migrated scope is green: per-scope `jest.config.*`, `jest.setup.*`, and any companion `jest.*.ts` (for example `jest.global-setup.ts`, `jest.global-teardown.ts`). Shared infrastructure to drop only when no other scope still relies on it (final scope only in a partial / mixed-mode migration): root `jest.config.*` with `projects: [...]`, any root shared setup, and devDeps `jest`, `ts-jest`, `@types/jest`, `jest-environment-jsdom`, `identity-obj-proxy`.
-2. **Defer snapshot re-recording until everything else is green.** Jest's `:` separator in snapshot keys changes to Rstest's `>` (see "Snapshot format" in the official guide), so every snapshot mismatches on the first `rstest` run. Running `rstest -u` too early masks real test failures under formatting noise. Migrate config/API/deps first; run `-u` only when the remaining failures are exclusively key-format mismatches.
+1. Delete scope-local `jest.config.*`, `jest.setup.*`, and companion `jest.*.ts` only after the migrated scope is green. Drop shared Jest devDeps only after no scope still uses Jest.
+2. Defer snapshot re-recording until all non-snapshot failures are fixed. Jest `:` snapshot key separators become Rstest `>`, so early `rstest -u` creates noisy churn.
+3. Review snapshot diffs by body, not key churn. Separator-only key renames are formatting; body changes are behavior signals.

--- a/skills/migrate-to-rstest/references/jest-migration-deltas.md
+++ b/skills/migrate-to-rstest/references/jest-migration-deltas.md
@@ -21,7 +21,7 @@ When local docs are available, prefer the checked-out source, for example `websi
 - Hooks: `beforeEach` / `beforeAll` return values are cleanup functions in Rstest. Wrap setup-only arrow expressions in braces when needed.
 - Environment: `testEnvironmentOptions` becomes `testEnvironment: { name, options }`; file-level Jest environment comments are recognized during migration, but `@rstest-environment` is native.
 - CJS mocking: use `rs.mockRequire()` for code paths using `require()`.
-- Coverage: install the matching Rstest provider; Jest `coverageProvider: 'babel'` maps to Rstest `istanbul`, and Jest `coverageProvider: 'v8'` maps to Rstest `v8` with `@rstest/coverage-v8`.
+- Coverage: install a Rstest provider supported by the target version. Jest `coverageProvider: 'babel'` maps to Rstest `istanbul`; Jest `coverageProvider: 'v8'` maps to Rstest `v8` with `@rstest/coverage-v8` only on Rstest >= 0.10.2. Use Istanbul for Rstest 0.8.x targets unless the user accepts a toolchain upgrade.
 
 ## Version compatibility
 

--- a/skills/migrate-to-rstest/references/jest-migration-deltas.md
+++ b/skills/migrate-to-rstest/references/jest-migration-deltas.md
@@ -21,7 +21,7 @@ When local docs are available, prefer the checked-out source, for example `websi
 - Hooks: `beforeEach` / `beforeAll` return values are cleanup functions in Rstest. Wrap setup-only arrow expressions in braces when needed.
 - Environment: `testEnvironmentOptions` becomes `testEnvironment: { name, options }`; file-level Jest environment comments are recognized during migration, but `@rstest-environment` is native.
 - CJS mocking: use `rs.mockRequire()` for code paths using `require()`.
-- Coverage: install the matching Rstest provider; Jest `coverageProvider: 'babel'` maps to Rstest `istanbul`.
+- Coverage: install the matching Rstest provider; Jest `coverageProvider: 'babel'` maps to Rstest `istanbul`, and Jest `coverageProvider: 'v8'` maps to Rstest `v8` with `@rstest/coverage-v8`.
 
 ## Version compatibility
 

--- a/skills/migrate-to-rstest/references/vitest-migration-deltas.md
+++ b/skills/migrate-to-rstest/references/vitest-migration-deltas.md
@@ -21,7 +21,7 @@ When local docs are available, prefer the checked-out source, for example `websi
 - Setup: replace `@testing-library/jest-dom/vitest` with matcher registration via `expect.extend(...)` from `@rstest/core`.
 - Globals/APIs: imports from `vitest` -> `@rstest/core`; `vi.<api>` / `vitest.<api>` -> `rs.<api>`. Avoid mixing `vi` and `rs` in a migrated file.
 - Mocks: Rstest `rs.mock('./module')` looks for `__mocks__`; use `{ mock: true }` for auto-mock and `{ spy: true }` to preserve implementations while spying.
-- Async mock factories: Rstest supports async factory signatures, but Vitest patterns that await the actual module inside the factory are better migrated to static `importActual` imports plus a synchronous factory.
+- Async mock factories: Rstest does not support returning an async function when mocking a module value. Migrate Vitest patterns that await the actual module inside the factory to static `importActual` imports plus a synchronous factory.
 - CJS mocking: use `rs.mockRequire()` / `rs.doMockRequire()` for `require()` paths.
 
 ## Build config and version compatibility

--- a/skills/migrate-to-rstest/references/vitest-migration-deltas.md
+++ b/skills/migrate-to-rstest/references/vitest-migration-deltas.md
@@ -21,7 +21,7 @@ When local docs are available, prefer the checked-out source, for example `websi
 - Setup: replace `@testing-library/jest-dom/vitest` with matcher registration via `expect.extend(...)` from `@rstest/core`.
 - Globals/APIs: imports from `vitest` -> `@rstest/core`; `vi.<api>` / `vitest.<api>` -> `rs.<api>`. Avoid mixing `vi` and `rs` in a migrated file.
 - Mocks: Rstest `rs.mock('./module')` looks for `__mocks__`; use `{ mock: true }` for auto-mock and `{ spy: true }` to preserve implementations while spying.
-- Async mock factories: Rstest does not support async factory returns for module value mocking. Use static `importActual` imports and a synchronous factory.
+- Async mock factories: Rstest supports async factory signatures, but Vitest patterns that await the actual module inside the factory are better migrated to static `importActual` imports plus a synchronous factory.
 - CJS mocking: use `rs.mockRequire()` / `rs.doMockRequire()` for `require()` paths.
 
 ## Build config and version compatibility

--- a/skills/migrate-to-rstest/references/vitest-migration-deltas.md
+++ b/skills/migrate-to-rstest/references/vitest-migration-deltas.md
@@ -34,6 +34,6 @@ When local docs are available, prefer the checked-out source, for example `websi
 
 ## Vitest-specific enforcement
 
-1. Delete scope-local `vitest.config.*` and `vitest.setup.*` only after the migrated scope is green. Drop shared `vitest.workspace.*`, root shared config, and `@vitest/*` devDeps only after no scope still uses Vitest.
+1. Delete scope-local `vitest.config.*` and truly legacy `vitest.setup.*` only after the migrated scope is green. If a setup file was rewritten and is still referenced by Rstest `setupFiles`, rename or copy it to a Rstest-owned name such as `rstest.setup.*` before deleting the legacy Vitest-named file. Drop shared `vitest.workspace.*`, root shared config, and `@vitest/*` devDeps only after no scope still uses Vitest.
 2. Do not re-record Vitest snapshots just to update headers. Vitest and Rstest snapshot files are byte-compatible below the header line; run `-u` only for expected body diffs.
 3. Do not carry the Vite mental model into Rstest. Prefer adapters and Rsbuild/Rspack config translations over custom test rewrites.

--- a/skills/migrate-to-rstest/references/vitest-migration-deltas.md
+++ b/skills/migrate-to-rstest/references/vitest-migration-deltas.md
@@ -14,23 +14,19 @@ When local docs are available, prefer the checked-out source, for example `websi
 
 - Scripts: `vitest run` / `vitest --run` -> `rstest`; plain Rstest already runs once and exits. Watch mode is `rstest --watch` or `rstest watch`.
 - Config imports: `defineConfig` comes from `@rstest/core`; `defineWorkspace` is removed; use the `projects` field.
-- Projects: in latest Rstest, use `defineInlineProject({ name, ... })` for object entries inside `projects`; in Rstest 0.8.x, use plain named objects. Use `defineProject` for top-level project config exports.
+- Projects: use `defineInlineProject({ name, ... })` only when the `dependency-install-gate.md` capability gate allows it; otherwise use plain named objects. Use `defineProject` for top-level project config exports.
 - Config shape: remove Vitest's `test` wrapper and move fields to the Rstest top level. Map exact fields through the official guide.
-- Coverage: add Rstest coverage packages and use `coverage.reporters` (plural). Replace `@vitest/coverage-*` only during cleanup after the Rstest scope is green; `@rstest/coverage-v8` requires Rstest >= 0.10.2.
+- Coverage: add a capability-supported Rstest coverage package and use `coverage.reporters` (plural). Replace `@vitest/coverage-*` only during cleanup after the Rstest scope is green.
 - Reporters: replace Vitest-only reporters; import third-party reporter classes instead of passing incompatible names.
 - Setup: replace `@testing-library/jest-dom/vitest` with matcher registration via `expect.extend(...)` from `@rstest/core`.
 - Globals/APIs: imports from `vitest` -> `@rstest/core`; `vi.<api>` / `vitest.<api>` -> `rs.<api>`. Avoid mixing `vi` and `rs` in a migrated file.
-- Mocks: Rstest `rs.mock('./module')` looks for `__mocks__`; use `{ mock: true }` for auto-mock and `{ spy: true }` to preserve implementations while spying.
+- Mocks: `rs.mock('./module')` looks for `__mocks__`; use newer helpers/options such as `{ mock: true }` or `{ spy: true }` only when the `dependency-install-gate.md` capability gate allows them. Otherwise use explicit factories or manual mocks.
 - Async mock factories: Rstest does not support returning an async function when mocking a module value. Migrate Vitest patterns that await the actual module inside the factory to static `importActual` imports plus a synchronous factory.
 - CJS mocking: use `rs.mockRequire()` / `rs.doMockRequire()` for `require()` paths.
 
-## Build config and version compatibility
+## Build config
 
-- Rstest uses Rsbuild/Rspack instead of Vite/Rollup. Translate Vite `define` to `source.define`, externalization fixes to `output.externals`, and plugins to Rsbuild equivalents where available.
-- Prefer `@rstest/adapter-rslib` or `@rstest/adapter-rsbuild` when those configs already exist. Use `@rstest/adapter-rspack` only for Rspack 2.x projects; on Rspack 1.x / Rstest 0.8.x, port the necessary Rspack settings manually.
-- Latest Rstest uses Rsbuild/Rspack 2.x; Rstest 0.8.x uses Rsbuild/Rspack 1.x.
-- Vite -> Rstest migrations often add `@rsbuild/plugin-*`; choose plugin versions that satisfy the installed `@rsbuild/core` peer range.
-- Treat Rsbuild/Rspack/plugin schema or peer errors as dependency skew first, not as a reason to rewrite tests.
+- Rstest uses Rsbuild/Rspack instead of Vite/Rollup. Translate Vite `define` to `source.define`, externalization to `output.externals`, and plugins to compatible adapters/Rsbuild plugins before rewriting tests.
 
 ## Vitest-specific enforcement
 

--- a/skills/migrate-to-rstest/references/vitest-migration-deltas.md
+++ b/skills/migrate-to-rstest/references/vitest-migration-deltas.md
@@ -4,11 +4,36 @@ Use this reference when the current framework is Vitest.
 
 ## Source of truth
 
-Follow the official migration guide for all Vitest → Rstest field/API mapping (config table, CLI option mapping, setup adapter rewrite, mock-async pattern, path-resolution caveat, `mergeConfig` substitute, etc.):
+Use the official guide for exact field/API mappings:
 
 https://rstest.rs/guide/migration/vitest.md
 
+When local docs are available, prefer the checked-out source, for example `website/docs/en/guide/migration/vitest.mdx`.
+
+## High-signal deltas
+
+- Scripts: `vitest run` / `vitest --run` -> `rstest`; plain Rstest already runs once and exits. Watch mode is `rstest --watch` or `rstest watch`.
+- Config imports: `defineConfig` comes from `@rstest/core`; `defineWorkspace` is removed; use the `projects` field.
+- Projects: use `defineInlineProject({ name, ... })` for object entries inside `projects`; use `defineProject` for top-level project config exports.
+- Config shape: remove Vitest's `test` wrapper and move fields to the Rstest top level. Map exact fields through the official guide.
+- Coverage: replace `@vitest/coverage-*` with Rstest coverage packages and use `coverage.reporters` (plural).
+- Reporters: replace Vitest-only reporters; import third-party reporter classes instead of passing incompatible names.
+- Setup: replace `@testing-library/jest-dom/vitest` with matcher registration via `expect.extend(...)` from `@rstest/core`.
+- Globals/APIs: imports from `vitest` -> `@rstest/core`; `vi.<api>` / `vitest.<api>` -> `rs.<api>`. Avoid mixing `vi` and `rs` in a migrated file.
+- Mocks: Rstest `rs.mock('./module')` looks for `__mocks__`; use `{ mock: true }` for auto-mock and `{ spy: true }` to preserve implementations while spying.
+- Async mock factories: Rstest does not support async factory returns for module value mocking. Use static `importActual` imports and a synchronous factory.
+- CJS mocking: use `rs.mockRequire()` / `rs.doMockRequire()` for `require()` paths.
+
+## Build config and version compatibility
+
+- Rstest uses Rsbuild/Rspack instead of Vite/Rollup. Translate Vite `define` to `source.define`, externalization fixes to `output.externals`, and plugins to Rsbuild equivalents where available.
+- Prefer `@rstest/adapter-rslib`, `@rstest/adapter-rsbuild`, or `@rstest/adapter-rspack` when those configs already exist.
+- Latest Rstest uses Rsbuild/Rspack 2.x; Rstest 0.8.x uses Rsbuild/Rspack 1.x.
+- Vite -> Rstest migrations often add `@rsbuild/plugin-*`; choose plugin majors matching `@rsbuild/core`.
+- Treat Rsbuild/Rspack/plugin schema or peer errors as dependency skew first, not as a reason to rewrite tests.
+
 ## Vitest-specific enforcement
 
-1. **Legacy file enumeration for phase (b) of SKILL principle 6.** Scope-local legacy files to delete once the migrated scope is green: per-scope `vitest.config.*` and `vitest.setup.*` owned by the migrated package only (rename `vitest.setup.*` → `rstest.setup.*` only when the file is genuinely reused). Shared infrastructure to drop only when no other scope still relies on it (final scope only in a partial / mixed-mode migration): root `vitest.workspace.*`, any root shared `vitest.config.*` / `vitest.shared.*`, and devDeps `vitest`, `@vitest/coverage-v8`, and any other `@vitest/*` packages.
-2. **Do not re-record Vitest snapshots.** Vitest and Rstest snapshot files are byte-compatible below the header line (see the "Snapshots" section in the official guide). Running `rstest -u` during a Vitest → Rstest migration rewrites every snapshot file's first line with zero behavioral change and floods the migration diff. Only run `-u` when a snapshot test is actually failing and the body diff is expected.
+1. Delete scope-local `vitest.config.*` and `vitest.setup.*` only after the migrated scope is green. Drop shared `vitest.workspace.*`, root shared config, and `@vitest/*` devDeps only after no scope still uses Vitest.
+2. Do not re-record Vitest snapshots just to update headers. Vitest and Rstest snapshot files are byte-compatible below the header line; run `-u` only for expected body diffs.
+3. Do not carry the Vite mental model into Rstest. Prefer adapters and Rsbuild/Rspack config translations over custom test rewrites.

--- a/skills/migrate-to-rstest/references/vitest-migration-deltas.md
+++ b/skills/migrate-to-rstest/references/vitest-migration-deltas.md
@@ -14,7 +14,7 @@ When local docs are available, prefer the checked-out source, for example `websi
 
 - Scripts: `vitest run` / `vitest --run` -> `rstest`; plain Rstest already runs once and exits. Watch mode is `rstest --watch` or `rstest watch`.
 - Config imports: `defineConfig` comes from `@rstest/core`; `defineWorkspace` is removed; use the `projects` field.
-- Projects: use `defineInlineProject({ name, ... })` for object entries inside `projects`; use `defineProject` for top-level project config exports.
+- Projects: in latest Rstest, use `defineInlineProject({ name, ... })` for object entries inside `projects`; in Rstest 0.8.x, use plain named objects. Use `defineProject` for top-level project config exports.
 - Config shape: remove Vitest's `test` wrapper and move fields to the Rstest top level. Map exact fields through the official guide.
 - Coverage: replace `@vitest/coverage-*` with Rstest coverage packages and use `coverage.reporters` (plural).
 - Reporters: replace Vitest-only reporters; import third-party reporter classes instead of passing incompatible names.
@@ -27,9 +27,9 @@ When local docs are available, prefer the checked-out source, for example `websi
 ## Build config and version compatibility
 
 - Rstest uses Rsbuild/Rspack instead of Vite/Rollup. Translate Vite `define` to `source.define`, externalization fixes to `output.externals`, and plugins to Rsbuild equivalents where available.
-- Prefer `@rstest/adapter-rslib`, `@rstest/adapter-rsbuild`, or `@rstest/adapter-rspack` when those configs already exist.
+- Prefer `@rstest/adapter-rslib` or `@rstest/adapter-rsbuild` when those configs already exist. Use `@rstest/adapter-rspack` only for Rspack 2.x projects; on Rspack 1.x / Rstest 0.8.x, port the necessary Rspack settings manually.
 - Latest Rstest uses Rsbuild/Rspack 2.x; Rstest 0.8.x uses Rsbuild/Rspack 1.x.
-- Vite -> Rstest migrations often add `@rsbuild/plugin-*`; choose plugin majors matching `@rsbuild/core`.
+- Vite -> Rstest migrations often add `@rsbuild/plugin-*`; choose plugin versions that satisfy the installed `@rsbuild/core` peer range.
 - Treat Rsbuild/Rspack/plugin schema or peer errors as dependency skew first, not as a reason to rewrite tests.
 
 ## Vitest-specific enforcement

--- a/skills/migrate-to-rstest/references/vitest-migration-deltas.md
+++ b/skills/migrate-to-rstest/references/vitest-migration-deltas.md
@@ -16,7 +16,7 @@ When local docs are available, prefer the checked-out source, for example `websi
 - Config imports: `defineConfig` comes from `@rstest/core`; `defineWorkspace` is removed; use the `projects` field.
 - Projects: in latest Rstest, use `defineInlineProject({ name, ... })` for object entries inside `projects`; in Rstest 0.8.x, use plain named objects. Use `defineProject` for top-level project config exports.
 - Config shape: remove Vitest's `test` wrapper and move fields to the Rstest top level. Map exact fields through the official guide.
-- Coverage: replace `@vitest/coverage-*` with Rstest coverage packages and use `coverage.reporters` (plural).
+- Coverage: add Rstest coverage packages and use `coverage.reporters` (plural). Replace `@vitest/coverage-*` only during cleanup after the Rstest scope is green; `@rstest/coverage-v8` requires Rstest >= 0.10.2.
 - Reporters: replace Vitest-only reporters; import third-party reporter classes instead of passing incompatible names.
 - Setup: replace `@testing-library/jest-dom/vitest` with matcher registration via `expect.extend(...)` from `@rstest/core`.
 - Globals/APIs: imports from `vitest` -> `@rstest/core`; `vi.<api>` / `vitest.<api>` -> `rs.<api>`. Avoid mixing `vi` and `rs` in a migrated file.


### PR DESCRIPTION
## Summary

This PR refines the `migrate-to-rstest` skill into a lean migration playbook instead of duplicating the official Rstest migration docs.

It centralizes version and capability checks in the dependency install gate, especially for Rstest 0.8.x with Rsbuild/Rspack 1.x versus latest Rstest with Rsbuild/Rspack 2.x. The Jest/Vitest reference files now focus on high-risk migration deltas and point back to the shared gate for latest-only APIs, adapter/plugin peer compatibility, coverage providers, and fallback choices.

The goal is to keep the skill concise while still preventing common migration failures caused by mismatched Rstest, Rsbuild, Rspack, adapter, plugin, Node, or coverage-provider versions.