### PR TITLE
docs: update pr creator workflow

### DIFF
--- a/skills/pr-creator/SKILL.md
+++ b/skills/pr-creator/SKILL.md
@@ -22,6 +22,7 @@ description: Use when asked to create a pull request for this repository. It hel
    - `fix(types): ...`
    - `docs: ...`
    - `refactor(types): ...`
+   - `chore(ci): ...` for CI workflow, check, or release automation changes
    - `chore(deps): ...`
    - `release: v1.2.0`
 
@@ -43,7 +44,9 @@ description: Use when asked to create a pull request for this repository. It hel
 
 7. Push the branch only after re-checking the branch name. Never push the default branch directly.
 
-8. Create the PR with `gh pr create`.
+8. Create the PR.
+   When running in Codex, use the Codex GitHub connector/plugin for GitHub operations.
+   Use `gh pr create` only as a fallback when the connector is unavailable.
 
 ## Constraints
 


### PR DESCRIPTION
## Summary

This PR updates the PR creator skill so Codex-based runs prefer the Codex GitHub connector for PR creation, with `gh pr create` kept as a fallback. It also documents `chore(ci): ...` as the title prefix for CI workflow, check, and release automation changes.