### PR TITLE
docs: update release blog writer guidance

### DIFF
--- a/skills/release-blog-writer/SKILL.md
+++ b/skills/release-blog-writer/SKILL.md
@@ -25,7 +25,7 @@ Use the project's existing blog metadata and component conventions. If the produ
 Each feature section should usually follow this pattern:
 
 - Describe the change clearly so readers understand its background, purpose, use cases, and user-facing benefits such as performance gains.
-- If a code or configuration example is useful, include one precise and concise example that makes the change easy to understand at a glance.
+- Avoid exhaustive API lists; select the key APIs or behaviors readers need, and when useful, use one precise code or configuration example to make the change clear at a glance.
 
 ## Headings
 
@@ -40,6 +40,7 @@ Each feature section should usually follow this pattern:
 - Avoid vague claims such as "greatly improved" unless the improvement is explained or quantified.
 - Avoid slogan-like positioning in feature updates unless intentionally discussing product vision.
 - Qualify benchmark numbers with enough context to make them credible.
+- When presenting performance gains, bold only the key improvement numbers, avoid frequent emphasis, and use tables or images when they make the comparison clearer at a glance.
 - Use product and ecosystem terms consistently.
 - Write naturally in the target language; do not let the prose read like a literal translation from another language.
 


### PR DESCRIPTION
## Summary

This PR refines the release blog writer skill so feature sections focus on the key APIs or behaviors readers need instead of exhaustive API lists. It also clarifies how to present performance gains with restrained emphasis and clearer comparison formats such as tables or images when useful.