### PR TITLE
feat: add mdx to markdown skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,14 @@ npx skills add rstackjs/agent-skills --skill release-blog-writer
 
 Write or revise release blog posts for product releases, with guidance for structure, tone, headings, examples, and links.
 
+### mdx-to-markdown
+
+```bash
+npx skills add rstackjs/agent-skills --skill mdx-to-markdown
+```
+
+Convert MDX to portable Markdown with MDX syntax cleanup and link/code block normalization.
+
 ### pr-creator
 
 ```bash

--- a/skills/mdx-to-markdown/SKILL.md
+++ b/skills/mdx-to-markdown/SKILL.md
@@ -41,8 +41,12 @@ Use this skill to produce plain Markdown from MDX without requiring the target r
 - Convert code-fence titles or standalone bold filename captions into the first line of the code block as a comment, for example:
 
   ```js
-  // env.js
-  export const IS_DEV = false;
+  // hello.js
+  export function greet(name) {
+    return `Hello, ${name}!`;
+  }
+
+  console.log(greet('world'));
   ```
 
 - Convert code blocks that contain markers such as `// [!code highlight]` to `diff` code blocks, remove the marker, and prefix highlighted lines with `+`.

--- a/skills/mdx-to-markdown/SKILL.md
+++ b/skills/mdx-to-markdown/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: mdx-to-markdown
+description: Convert `.mdx` to portable `.md`, cleaning MDX components, anchors, code titles, table-of-contents links, and root-relative docs links.
+---
+
+# MDX to Markdown
+
+## Overview
+
+Use this skill to produce plain Markdown from MDX without requiring the target renderer to understand MDX imports, JSX components, Rspress anchors, or code-block metadata.
+
+## Workflow
+
+1. Identify the source `.mdx` and target `.md` path. If the user gives only a source path, default the output to the same path with `.md`.
+2. Inspect the MDX for non-Markdown constructs:
+   - YAML frontmatter.
+   - top-level `import` lines.
+   - custom components such as `<BlogAuthors />` and `<PackageManagerTabs />`.
+   - heading anchors like `### Title \{#title}`.
+   - standalone HTML anchors like `<a id="title"></a>`.
+   - fenced code block titles such as a JavaScript fence with `title="env.js"`.
+   - HTML image wrappers such as centered `<div><img ... /></div>`.
+3. Run the helper script when the requested conversion matches the default rules:
+
+   ```bash
+   node /path/to/skills/mdx-to-markdown/scripts/convert_mdx_to_markdown.mjs input.mdx output.md
+   ```
+
+4. Review the result with `rg` and a short diff. Confirm that no MDX-only syntax remains.
+5. Apply any user-requested follow-up edits, such as removing a generated table of contents or changing link policy.
+
+## Default Conversion Rules
+
+- Drop YAML frontmatter and top-level MDX imports.
+- Remove `<BlogAuthors />`.
+- Expand `<PackageManagerTabs command="add pkg -D" />` to a `bash` code block using `pnpm add pkg -D`.
+- Convert centered HTML image blocks into Markdown image syntax.
+- Remove Rspress heading anchor suffixes while keeping the heading text.
+- Remove standalone `<a id="..."></a>` anchor lines.
+- Remove table-of-contents links that target in-page anchors, preserving the list text.
+- Convert code-fence titles or standalone bold filename captions into the first line of the code block as a comment, for example:
+
+  ```js
+  // env.js
+  export const IS_DEV = false;
+  ```
+
+- Convert code blocks that contain markers such as `// [!code highlight]` to `diff` code blocks, remove the marker, and prefix highlighted lines with `+`.
+- Prefix Markdown links whose target starts with `/` using the current repository's site domain. Infer the product from the input file's Git repository, remote, package name, or path segment:
+  - `rspack` -> `rspack.rs`
+  - `rsbuild` -> `rsbuild.rs`
+  - `rspress` -> `rspress.rs`
+  - `rslib` -> `rslib.rs`
+  - `rsdoctor` -> `rsdoctor.rs`
+  - `rstest` -> `rstest.rs`
+- Add `/zh` to the prefix when the MDX path contains a `zh` path segment. For example, a Chinese Rspack document converts `/guide/optimization/tree-shaking` to `http://rspack.rs/zh/guide/optimization/tree-shaking`.
+- Use `--link-prefix <prefix>` only when the inferred domain is wrong or the user explicitly requests a custom prefix.
+
+## Validation Checklist
+
+Run targeted checks after conversion:
+
+````bash
+rg -n '<BlogAuthors|PackageManagerTabs|title="|\\{#|^<a id="|\\]\(/|!code highlight|^\*\*[^*]+\*\*$' output.md
+rg -n '^```' output.md | wc -l
+````
+
+The first command should return no matches unless the user intentionally kept that syntax. The fence count should be even.
+
+## Resources
+
+- `scripts/convert_mdx_to_markdown.mjs`: deterministic converter for the common Rspack/Rstack release-blog MDX pattern.

--- a/skills/mdx-to-markdown/SKILL.md
+++ b/skills/mdx-to-markdown/SKILL.md
@@ -53,7 +53,7 @@ Use this skill to produce plain Markdown from MDX without requiring the target r
   - `rslib` -> `rslib.rs`
   - `rsdoctor` -> `rsdoctor.rs`
   - `rstest` -> `rstest.rs`
-- Add `/zh` to the prefix when the MDX path contains a `zh` path segment. For example, a Chinese Rspack document converts `/guide/optimization/tree-shaking` to `http://rspack.rs/zh/guide/optimization/tree-shaking`.
+- Add `/zh` to the prefix when the MDX path contains a `zh` path segment. For example, a Chinese Rspack document converts `/guide/optimization/tree-shaking` to `https://rspack.rs/zh/guide/optimization/tree-shaking`.
 - Use `--link-prefix <prefix>` only when the inferred domain is wrong or the user explicitly requests a custom prefix.
 
 ## Validation Checklist

--- a/skills/mdx-to-markdown/scripts/convert_mdx_to_markdown.mjs
+++ b/skills/mdx-to-markdown/scripts/convert_mdx_to_markdown.mjs
@@ -1,0 +1,266 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { basename, dirname, extname, join } from "node:path";
+
+const SITE_DOMAINS = {
+  rspack: "rspack.rs",
+  rsbuild: "rsbuild.rs",
+  rspress: "rspress.rs",
+  rslib: "rslib.rs",
+  rsdoctor: "rsdoctor.rs",
+  rstest: "rstest.rs",
+};
+
+const COMMENT_PREFIX = {
+  bash: "#",
+  sh: "#",
+  shell: "#",
+  css: "/*",
+  scss: "/*",
+  less: "/*",
+  html: "<!--",
+  xml: "<!--",
+};
+
+const CODE_HIGHLIGHT_MARKER = /\s*\/\/\s*\[!code highlight\]\s*$/;
+
+function commentLine(language, title) {
+  const prefix = COMMENT_PREFIX[language];
+  if (prefix === "/*") return `/* ${title} */`;
+  if (prefix === "<!--") return `<!-- ${title} -->`;
+  if (prefix === "#") return `# ${title}`;
+  return `// ${title}`;
+}
+
+function stripFrontmatter(text) {
+  if (!text.startsWith("---\n")) return text;
+  const end = text.indexOf("\n---", 4);
+  if (end === -1) return text;
+  const after = text.indexOf("\n", end + 4);
+  return after === -1 ? "" : text.slice(after + 1);
+}
+
+function replacePackageTabs(text) {
+  return text.replace(
+    /<PackageManagerTabs\s+command="([^"]+)"\s*\/>/g,
+    (_, command) => `\`\`\`bash\npnpm ${command.trim()}\n\`\`\``,
+  );
+}
+
+function replaceCenteredImages(text) {
+  return text.replace(
+    /<div\s+align="center">\s*\n\s*<img\s+(?=[^>]*\bsrc="([^"]+)")(?=[^>]*\balt="([^"]*)")[^>]*\/>\s*\n\s*<\/div>/g,
+    (_, src, alt) => `![${alt}](${src})`,
+  );
+}
+
+function normalizeLines(text, linkPrefix) {
+  const lines = text.split(/\r?\n/);
+  const output = [];
+  let pendingTitle = null;
+  let fence = null;
+
+  const emitFence = () => {
+    const hasHighlight = fence.lines.some(line => CODE_HIGHLIGHT_MARKER.test(line));
+    const language = hasHighlight ? "diff" : fence.language;
+    output.push(`\`\`\`${language}`);
+    if (fence.title) output.push(commentLine(language, fence.title));
+
+    for (let line of fence.lines) {
+      if (CODE_HIGHLIGHT_MARKER.test(line)) {
+        line = line.replace(CODE_HIGHLIGHT_MARKER, "");
+        output.push(`+${line}`);
+      } else {
+        output.push(line);
+      }
+    }
+
+    output.push("```");
+    fence = null;
+  };
+
+  for (const rawLine of lines) {
+    let line = rawLine;
+
+    if (fence) {
+      if (line === "```") {
+        emitFence();
+      } else {
+        fence.lines.push(line);
+      }
+      continue;
+    }
+
+    if (/^\s*import\s+.+?;\s*$/.test(line)) continue;
+    if (line.trim() === "<BlogAuthors />") continue;
+    if (/^<a id="[^"]+"><\/a>$/.test(line.trim())) continue;
+
+    const heading = line.match(/^(#{1,6}\s+.+?)\s+\\\{#[A-Za-z0-9_-]+\}$/);
+    if (heading) line = heading[1];
+
+    const caption = line.match(/^\*\*([^*]+)\*\*$/);
+    if (caption) {
+      pendingTitle = caption[1];
+      continue;
+    }
+
+    const fenceWithTitle = line.match(/^```([A-Za-z0-9_-]+)\s+title="([^"]+)"$/);
+    if (fenceWithTitle) {
+      const [, language, title] = fenceWithTitle;
+      fence = { language, title, lines: [] };
+      pendingTitle = null;
+      continue;
+    }
+
+    const plainFence = line.match(/^```([A-Za-z0-9_-]*)$/);
+    if (plainFence) {
+      fence = { language: plainFence[1], title: pendingTitle, lines: [] };
+      pendingTitle = null;
+      continue;
+    }
+
+    const toc = line.match(/^(\s*-\s+)\[([^\]]+)\]\(#[^)]+\)(.*)$/);
+    if (toc) line = `${toc[1]}${toc[2]}${toc[3]}`;
+    if (linkPrefix) {
+      const prefix = linkPrefix.replace(/\/$/, "");
+      line = line.replace(/(^|[^!])(\[[^\n]*?\]\()\/(?!\/)/g, `$1$2${prefix}/`);
+    }
+
+    output.push(line);
+  }
+
+  if (fence) emitFence();
+
+  return `${output.join("\n").trim()}\n`;
+}
+
+function convert(text, linkPrefix) {
+  return normalizeLines(
+    replaceCenteredImages(replacePackageTabs(stripFrontmatter(text))),
+    linkPrefix,
+  );
+}
+
+function readJson(path) {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function gitOutput(cwd, args) {
+  try {
+    return execFileSync("git", ["-C", cwd, ...args], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return "";
+  }
+}
+
+function findGitRoot(inputPath) {
+  return gitOutput(dirname(inputPath), ["rev-parse", "--show-toplevel"]);
+}
+
+function repositoryCandidates(inputPath, gitRoot) {
+  const candidates = [];
+  const add = value => {
+    if (value) candidates.push(value.toLowerCase());
+  };
+
+  add(basename(gitRoot || dirname(inputPath)));
+
+  const remoteUrl = gitRoot
+    ? gitOutput(gitRoot, ["config", "--get", "remote.origin.url"])
+    : "";
+  const remoteName = remoteUrl.match(/([^/:]+?)(?:\.git)?$/)?.[1];
+  add(remoteName);
+
+  for (let current = dirname(inputPath); ; current = dirname(current)) {
+    const pkg = readJson(join(current, "package.json"));
+    if (pkg) {
+      add(pkg.name);
+      add(pkg.name?.split("/").pop());
+    }
+    if (current === gitRoot || current === dirname(current)) break;
+  }
+
+  for (const part of inputPath.split(/[\\/]+/)) {
+    add(part);
+  }
+
+  return candidates;
+}
+
+function detectProduct(inputPath, gitRoot) {
+  for (const candidate of repositoryCandidates(inputPath, gitRoot)) {
+    const normalized = candidate.replace(/^@rstackjs\//, "");
+    if (SITE_DOMAINS[normalized]) return normalized;
+    for (const product of Object.keys(SITE_DOMAINS)) {
+      if (normalized.startsWith(`${product}-`)) return product;
+    }
+  }
+  return null;
+}
+
+function detectLocalePrefix(inputPath) {
+  const parts = inputPath.split(/[\\/]+/);
+  if (parts.includes("zh")) return "/zh";
+  return "";
+}
+
+function inferLinkPrefix(inputPath) {
+  const gitRoot = findGitRoot(inputPath);
+  const product = detectProduct(inputPath, gitRoot);
+  if (!product) return null;
+  return `http://${SITE_DOMAINS[product]}${detectLocalePrefix(inputPath)}`;
+}
+
+function usage() {
+  console.error(
+    "Usage: convert_mdx_to_markdown.mjs <input.mdx> [output.md] [--link-prefix <prefix>]",
+  );
+}
+
+function parseArgs(argv) {
+  const args = [...argv];
+  let linkPrefix;
+  const positional = [];
+
+  while (args.length) {
+    const arg = args.shift();
+    if (arg === "--link-prefix") {
+      linkPrefix = args.shift();
+      if (!linkPrefix) throw new Error("--link-prefix requires a value");
+      continue;
+    }
+    positional.push(arg);
+  }
+
+  if (positional.length < 1 || positional.length > 2) {
+    throw new Error("expected one input path and optional output path");
+  }
+
+  return {
+    input: positional[0],
+    output:
+      positional[1] ??
+      join(dirname(positional[0]), `${basename(positional[0], extname(positional[0]))}.md`),
+    linkPrefix,
+  };
+}
+
+try {
+  const { input, output, linkPrefix } = parseArgs(process.argv.slice(2));
+  const text = readFileSync(input, "utf8");
+  writeFileSync(output, convert(text, linkPrefix ?? inferLinkPrefix(input)), "utf8");
+  console.log(`Wrote ${output}`);
+} catch (error) {
+  usage();
+  console.error(error.message);
+  process.exitCode = 1;
+}

--- a/skills/mdx-to-markdown/scripts/convert_mdx_to_markdown.mjs
+++ b/skills/mdx-to-markdown/scripts/convert_mdx_to_markdown.mjs
@@ -217,7 +217,7 @@ function inferLinkPrefix(inputPath) {
   const gitRoot = findGitRoot(inputPath);
   const product = detectProduct(inputPath, gitRoot);
   if (!product) return null;
-  return `http://${SITE_DOMAINS[product]}${detectLocalePrefix(inputPath)}`;
+  return `https://${SITE_DOMAINS[product]}${detectLocalePrefix(inputPath)}`;
 }
 
 function usage() {


### PR DESCRIPTION
## Summary

This PR adds an `mdx-to-markdown` skill for converting Rstack MDX docs and release posts into portable Markdown. It includes a Node.js helper script that removes MDX-only syntax, normalizes code block titles and highlighted lines, cleans table-of-contents anchors, and infers the correct Rstack docs domain for root-relative links.

The README is updated with the new skill installation entry.