### PR TITLE
optimize: add ROI triage to rsdoctor analysis

### DIFF
--- a/skills/rsdoctor-analysis/SKILL.md
+++ b/skills/rsdoctor-analysis/SKILL.md
@@ -16,9 +16,30 @@ Response order (required): High-Priority Issues -> Proposed Solutions -> Optiona
 3. If data exists, skip all plugin version/config/build generation logic. Update cache when useful.
 4. If data is missing, stop analysis: do not run `rsdoctor-agent` analysis commands, do not run the Analysis Gate, and either ask for the data path or run the Generation Gate below only when setup/generation is required.
 5. After a real data file exists, run Analysis Gate at most once before the first `rsdoctor-agent` data-fetch command: verify global `@rsdoctor/agent-cli` with `npm view @rsdoctor/agent-cli version` and `rsdoctor-agent --version`; install latest only if missing/outdated, a version-related error occurs, or the user asks to refresh.
-6. Fetch only the Default Evidence Set first; run independent fetches in parallel when possible; synthesize findings in the required response order.
+6. Fetch only the Default Evidence Set first; run independent fetches in parallel when possible.
+7. Run the ROI Triage Gate below before selecting deep-dive commands or recommendations. Use it to rank issue categories by measured impact, then synthesize findings in the required response order.
 
 Performance rules: parallelize independent checks, cache only derived facts (`dataFile`, `dataFileMtime`, `pluginName`, `pluginVersion`, dependency/config/plugin modification times), and invalidate cache when paths disappear, modification times change, the user asks to refresh, or cached values fail. Speculative plugin checks must not trigger generation; use them only after confirming the data file is missing.
+
+## ROI Triage Gate
+
+Before recommending fixes, classify the current build into broad cost buckets and choose the highest-ROI lever from evidence, not intuition. This gate is generic for Rspack/Webpack projects; do not use framework-specific runtime layers unless the user's project exposes them in the data.
+
+| Cost bucket                | Evidence source                                                   | First lever                                                                                                                      |
+| -------------------------- | ----------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| Assets/media               | `assetsTop`, `assets media`, `chunkGraph.assets`                  | Compress, convert, deduplicate, subset, or lazy-load large assets                                                                |
+| Large packages/modules     | `packagesTop`, module/package size fields                         | Replace heavy packages, use deep imports, split non-critical code, or review direct dependency choices                           |
+| Duplicate/cross-chunk cost | E1001/E1002, `packages duplicates`, cross-chunk package summaries | Deduplicate versions, tune package resolution, or adjust `splitChunks`/cache groups                                              |
+| Tree-shaking waste         | `retainedModulesTop`, retained CJS/barrel/side-effects modules    | Fix CJS/barrel imports, sideEffects declarations, or package entrypoints                                                         |
+| Build-time cost            | `buildCost`, loaders/plugins/directories cost data                | Optimize loaders/plugins, cache, watcher, or source-map/dev settings; prioritize only when the user asks about build performance |
+
+Decision rules:
+
+- Report the measured breakdown first when it changes recommendation priority.
+- Start with the largest bucket that maps to a practical fix; a smaller issue should not outrank a larger one unless the larger one is expected or intentionally unavoidable.
+- Treat issuer/reference-chain tracing as second-pass work. Run it only when a high-impact candidate needs ownership evidence, or when the user asks "why" / "who imported this".
+- Do not present aggregate rule output as sufficient evidence for a fix that requires a concrete file, package, chunk, size, or dependency path.
+- If the largest bucket is structural or intentionally required, say that it is a wall and name the external change that would be needed instead of inventing low-impact source edits.
 
 ## Generation Gate
 

--- a/skills/rsdoctor-analysis/references/common-analysis-patterns.md
+++ b/skills/rsdoctor-analysis/references/common-analysis-patterns.md
@@ -2,6 +2,38 @@
 
 Use this reference for common Rspack/Webpack bundle analysis questions after locating `rsdoctor-data.json`.
 
+## ROI-Based Lever Selection
+
+Use this pattern before choosing detailed analysis commands. The goal is to find the biggest measured cost bucket first, then select the smallest follow-up that can prove or fix that bucket.
+
+Recommended triage order:
+
+1. Compare assets/media, top packages/modules, duplicate or cross-chunk cost, retained tree-shaking waste, and build-time cost.
+2. Pick the largest bucket with a plausible project-side fix.
+3. Fetch only the narrow supporting evidence required for that bucket.
+4. Defer issuer/reference-chain tracing until it will change ownership, confidence, or the recommended fix.
+5. If the largest bucket is expected or structurally required, call it out as a wall and move to the next meaningful bucket.
+
+Lever map:
+
+| Dominant bucket           | High-ROI first pass                                                                                               | Lower-ROI or second pass                                                    |
+| ------------------------- | ----------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| Assets/media              | Compress images, convert formats, deduplicate repeated assets, subset fonts, lazy-load non-critical media         | JS tree-shaking work that saves only tens of KB                             |
+| One or few large packages | Check direct dependency necessity, lighter alternatives, deep imports, async boundaries, or route-level splitting | Broad package-list browsing without a top offender                          |
+| Duplicate packages        | Use `packages duplicates` / E1001 evidence, then resolve compatible versions or alias deliberately                | Reference-chain tracing before the duplicate size is proven material        |
+| Cross-chunk duplication   | Inspect E1002/cross-chunk summaries, then consider `splitChunks`/cache group changes or shared vendor extraction  | Splitting small shared modules that add request overhead                    |
+| Retained modules          | Start with emitted CJS/barrel/side-effects rows sorted by gzip size                                               | Deleting source that is already eliminated by the bundler                   |
+| Build-time cost           | Use loader/plugin/directories timing and optimize the measured slow path                                          | Build-performance advice when the user asked only about shipped bundle size |
+
+Recommendation rules:
+
+- Prefer `gzipSize` for shipped-user cost and `parsedSize` for parse/execute or code-volume discussions.
+- For Webpack/Rspack chunk recommendations, distinguish initial/entry chunks from async chunks. A large async chunk is usually lower priority than a large initial chunk unless the user asks about that route or interaction.
+- For package replacement advice, require direct dependency evidence or clear ownership. Do not recommend replacing an indirect package just because it appears in `packageGraph`.
+- For duplicate-package advice, mention compatibility risk when versions cross major/minor boundaries or when packages may ship resources as side effects.
+- For retained-module advice, include the category (`cjs`, `barrel`, `side-effects`) and the largest concrete paths before suggesting config or source changes.
+- Stop when the likely savings are below the user's stated goal or clearly smaller than another measured bucket.
+
 ## Similar Packages
 
 Use direct dependency package data to inspect similar packages. Start with `packages direct-dependencies` or `query packages_direct_dependencies`, then check known package families and other potentially similar packages.


### PR DESCRIPTION
 This PR updates the rsdoctor-analysis skill to choose recommendations by measured ROI before deeper investigation. It adds a generic cost-
  bucket triage gate covering assets/media, package size, duplication, tree-shaking waste, and build-time cost, plus reusable guidance for
  selecting the highest-impact analysis lever before running lower-value tracing commands.