### PR TITLE
docs: improve Rstest migration diagnostics

### DIFF
--- a/skills/migrate-to-rstest/SKILL.md
+++ b/skills/migrate-to-rstest/SKILL.md
@@ -1,7 +1,9 @@
 ---
 name: migrate-to-rstest
-description: Migrate Jest or Vitest projects to Rstest. Use when asked to move from Jest/Vitest to Rstest, replace `jest`/`vi` APIs with `@rstest/core`, translate config into `rstest.config.ts`, update scripts/coverage/setup/mocks/snapshots/projects, or diagnose migration failures and memory/performance regressions caused by Rstest's Rsbuild/Rspack execution model, DOM dependency bundling, runtime-mocked module build graphs, or version skew.
+description: Migrate Jest or Vitest projects to Rstest. Use when asked to move from Jest/Vitest to Rstest, replace `jest`/`vi` APIs with `@rstest/core`, translate config into `rstest.config.ts`, update scripts/coverage/setup/mocks/snapshots/projects, or diagnose config-loading warnings, migration failures, and memory/performance regressions caused by Rstest's Rsbuild/Rspack execution model, DOM dependency bundling, runtime-mocked module build graphs, or version skew.
 ---
+
+<!-- cspell:words TYPELESS -->
 
 # Migrate to Rstest
 
@@ -15,11 +17,12 @@ Migrate Jest/Vitest tests and config to Rstest with minimal behavior changes. Us
 2. Run dependency/version gates (`references/dependency-install-gate.md`).
 3. Read only the needed deltas: Jest, Vitest, and/or global API replacement.
 4. Migrate scripts/config/setup before tests; prefer adapters or Rsbuild/Rspack config fixes before editing test bodies.
-5. Validate discovery/types/run, fixing failures in this order: dependency skew, config/resolver, setup/env/coverage, mocks/timers/snapshots, test bodies.
-6. If a `jsdom`, `happy-dom`, or other browser-like environment has much higher peak RSS or build cost than Jest/Vitest, compare equivalent runs and tune dependency bundling with `references/dom-dependency-bundling.md` before changing worker counts or test code.
-7. If a test fully mocks a heavy module but Rspack still compiles that module's source graph, run the narrow `output.externals` experiment in `references/mocked-module-build-graph.md`.
-8. After the scope is green, remove only scope-local legacy files and devDeps no remaining scope uses.
-9. Summarize changes, kept legacy files, unsupported fields, performance tradeoffs, and TODOs.
+5. If config loading emits `[MODULE_TYPELESS_PACKAGE_JSON]`, declare the config's module format with `references/config-module-type.md`; do not suppress the warning or change the whole package's module type without an audit.
+6. Validate discovery/types/run, fixing failures in this order: dependency skew, config/resolver, setup/env/coverage, mocks/timers/snapshots, test bodies.
+7. If a `jsdom`, `happy-dom`, or other browser-like environment has much higher peak RSS or build cost than Jest/Vitest, compare equivalent runs and tune dependency bundling with `references/dom-dependency-bundling.md` before changing worker counts or test code.
+8. If a test fully mocks a heavy module but Rspack still compiles that module's source graph, run the narrow `output.externals` experiment in `references/mocked-module-build-graph.md`.
+9. After the scope is green, remove only scope-local legacy files and devDeps no remaining scope uses.
+10. Summarize changes, kept legacy files, unsupported fields, performance tradeoffs, and TODOs.
 
 ## Guardrails
 
@@ -32,6 +35,7 @@ Migrate Jest/Vitest tests and config to Rstest with minimal behavior changes. Us
 
 - `rstest` / `rstest run` is single-run; watch mode is `rstest --watch` or `rstest watch`.
 - `globals` defaults to `false`; if globals remain, set `globals: true` and add `@rstest/core/globals` types.
+- An ESM-style `rstest.config.ts` in a package without an explicit module type can trigger Node's `[MODULE_TYPELESS_PACKAGE_JSON]` warning. Prefer `rstest.config.mts` for a CommonJS or mixed package; add `"type": "module"` only when the whole package is intentionally ESM-compatible.
 - Rstest runs on Rsbuild/Rspack. Use `references/dependency-install-gate.md` for latest-only APIs, coverage providers, adapters, plugins, and toolchain-version fallbacks.
 - Browser-like DOM environments bundle all third-party dependencies by default. Treat a peak-RSS regression as a possible build/bundling issue before assuming the migrated tests leak memory.
 - `rs.mock()` replaces a module at runtime; it does not by itself prune that module from Rspack's build graph. A fully mocked renderer, editor, or UI module can still pull a large source tree into compilation.

--- a/skills/migrate-to-rstest/SKILL.md
+++ b/skills/migrate-to-rstest/SKILL.md
@@ -21,7 +21,7 @@ Migrate Jest/Vitest tests and config to Rstest with minimal behavior changes. Us
 6. Validate discovery/types/run, fixing failures in this order: dependency skew, config/resolver, setup/env/coverage, mocks/timers/snapshots, test bodies.
 7. If a `jsdom`, `happy-dom`, or other browser-like environment has much higher peak RSS or build cost than Jest/Vitest, compare equivalent runs and tune dependency bundling with `references/dom-dependency-bundling.md` before changing worker counts or test code.
 8. If a test fully mocks a heavy module but Rspack still compiles that module's source graph, run the narrow `output.externals` experiment in `references/mocked-module-build-graph.md`.
-9. After the scope is green, remove only scope-local legacy files and devDeps no remaining scope uses.
+9. After the scope is green, remove only legacy files owned by that scope. Remove a devDep only after verifying that no other package or repository scope uses it.
 10. Summarize changes, kept legacy files, unsupported fields, performance tradeoffs, and TODOs.
 
 ## Guardrails

--- a/skills/migrate-to-rstest/SKILL.md
+++ b/skills/migrate-to-rstest/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: migrate-to-rstest
-description: Migrate Jest or Vitest projects to Rstest. Use when asked to move from Jest/Vitest to Rstest, replace `jest`/`vi` APIs with `@rstest/core`, translate config into `rstest.config.ts`, update scripts/coverage/setup/mocks/snapshots/projects, or diagnose migration failures caused by Rstest's Rsbuild/Rspack execution model or version skew.
+description: Migrate Jest or Vitest projects to Rstest. Use when asked to move from Jest/Vitest to Rstest, replace `jest`/`vi` APIs with `@rstest/core`, translate config into `rstest.config.ts`, update scripts/coverage/setup/mocks/snapshots/projects, or diagnose migration failures and memory/performance regressions caused by Rstest's Rsbuild/Rspack execution model, DOM dependency bundling, runtime-mocked module build graphs, or version skew.
 ---
 
 # Migrate to Rstest
@@ -16,8 +16,10 @@ Migrate Jest/Vitest tests and config to Rstest with minimal behavior changes. Us
 3. Read only the needed deltas: Jest, Vitest, and/or global API replacement.
 4. Migrate scripts/config/setup before tests; prefer adapters or Rsbuild/Rspack config fixes before editing test bodies.
 5. Validate discovery/types/run, fixing failures in this order: dependency skew, config/resolver, setup/env/coverage, mocks/timers/snapshots, test bodies.
-6. After the scope is green, remove only scope-local legacy files and devDeps no remaining scope uses.
-7. Summarize changes, kept legacy files, unsupported fields, and TODOs.
+6. If a `jsdom`, `happy-dom`, or other browser-like environment has much higher peak RSS or build cost than Jest/Vitest, compare equivalent runs and tune dependency bundling with `references/dom-dependency-bundling.md` before changing worker counts or test code.
+7. If a test fully mocks a heavy module but Rspack still compiles that module's source graph, run the narrow `output.externals` experiment in `references/mocked-module-build-graph.md`.
+8. After the scope is green, remove only scope-local legacy files and devDeps no remaining scope uses.
+9. Summarize changes, kept legacy files, unsupported fields, performance tradeoffs, and TODOs.
 
 ## Guardrails
 
@@ -31,6 +33,8 @@ Migrate Jest/Vitest tests and config to Rstest with minimal behavior changes. Us
 - `rstest` / `rstest run` is single-run; watch mode is `rstest --watch` or `rstest watch`.
 - `globals` defaults to `false`; if globals remain, set `globals: true` and add `@rstest/core/globals` types.
 - Rstest runs on Rsbuild/Rspack. Use `references/dependency-install-gate.md` for latest-only APIs, coverage providers, adapters, plugins, and toolchain-version fallbacks.
+- Browser-like DOM environments bundle all third-party dependencies by default. Treat a peak-RSS regression as a possible build/bundling issue before assuming the migrated tests leak memory.
+- `rs.mock()` replaces a module at runtime; it does not by itself prune that module from Rspack's build graph. A fully mocked renderer, editor, or UI module can still pull a large source tree into compilation.
 
 ## Escalate before large edits
 

--- a/skills/migrate-to-rstest/references/config-module-type.md
+++ b/skills/migrate-to-rstest/references/config-module-type.md
@@ -1,0 +1,61 @@
+# Rstest Config Module Type
+
+<!-- cspell:words TYPELESS -->
+
+Use this reference when loading `rstest.config.*` emits Node's `[MODULE_TYPELESS_PACKAGE_JSON]` warning.
+
+## Source of truth
+
+- Rstest configuration files: https://rstest.rs/guide/basic/configure-rstest
+- Rsbuild configuration loading: https://rsbuild.rs/guide/configuration/rsbuild
+- Node.js package module rules: https://nodejs.org/api/packages.html#determining-module-system
+
+## Understand the warning
+
+An Rstest TypeScript config normally uses ESM syntax:
+
+```ts
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({});
+```
+
+When the nearest controlling `package.json` has no `type` field, Node can initially treat the config as CommonJS, detect ESM syntax, and reparse it as an ES module. The warning reports that ambiguous module format and its extra parsing cost; it is not a test failure.
+
+Resolve the ambiguity instead of hiding the warning with `NODE_OPTIONS=--no-warnings`, stderr filtering, or a blanket warning ignore.
+
+## Choose the narrowest fix
+
+### CommonJS or mixed package
+
+Rename the config so only this file explicitly opts into ESM:
+
+```text
+rstest.config.ts -> rstest.config.mts
+```
+
+Rstest supports `.mts` config files. Update test scripts, CI commands, or documentation that pass an explicit `--config` / `-c` path. Remove or rename the old `.ts` config rather than leaving both files: automatic discovery checks `rstest.config.ts` before `rstest.config.mts`.
+
+For a JavaScript config, use `rstest.config.mjs` for the same narrow ESM declaration. Use `.cts` or `.cjs` only when the config is intentionally authored with CommonJS-compatible semantics.
+
+### Intentionally ESM package
+
+Adding the following to the nearest package-level `package.json` also removes the ambiguity:
+
+```json
+{
+  "type": "module"
+}
+```
+
+Choose this only when the package is already intended to be ESM. The field changes how Node interprets every affected `.js` file, so audit runtime scripts, config files, `require` / `module.exports`, `__dirname` / `__filename`, and tool integrations first. Do not turn a package into ESM merely to silence an Rstest config warning.
+
+In a monorepo, inspect the nearest `package.json` that controls the config path. Do not add `"type": "module"` at the workspace root when only one CommonJS package needs an unambiguous Rstest config.
+
+## Validate
+
+Run the same local or CI test command that produced the warning and confirm:
+
+1. Rstest discovers the intended config, including any explicit `--config` path.
+2. `[MODULE_TYPELESS_PACKAGE_JSON]` no longer appears.
+3. Config imports, setup, and the migrated test scope still pass.

--- a/skills/migrate-to-rstest/references/dom-dependency-bundling.md
+++ b/skills/migrate-to-rstest/references/dom-dependency-bundling.md
@@ -6,6 +6,7 @@ Use this reference when a migrated scope runs in `jsdom`, `happy-dom`, or anothe
 
 - Rstest output configuration: https://rstest.rs/config/build/output
 - Rstest profiling guide: https://rstest.rs/guide/advanced/profiling
+- Rspack lazy barrel optimization: https://rspack.rs/guide/optimization/lazy-barrel
 
 ## Understand the default
 
@@ -54,6 +55,18 @@ export default defineConfig({
 ```
 
 An array sets an externalized baseline and bundles only matching package requests. It does not re-bundle transitive dependencies that are reachable only through an already externalized parent.
+
+### Preserve measured lazy-barrel wins
+
+Treat full externalization as a diagnostic baseline, not an automatic final config. A bundled dependency can benefit from Rspack's default lazy barrel optimization, which skips building unused re-export branches in an eligible barrel file.
+
+Consider adding a package back to the `bundleDependencies` allowlist only when all of these signals are present:
+
+- The relevant entry or barrel file uses ESM, and the test imports a small subset through named exports. CommonJS is unsupported, and `export *` re-exports have limited optimization.
+- The relevant barrel path is explicitly side-effect-free through package metadata (`"sideEffects": false`, or a `sideEffects` pattern that does not match it) or `rules[].sideEffects: false`. Merely enabling `optimization.sideEffects` is not enough for lazy barrel's early build skipping.
+- The package is large or frequently imported enough that avoiding its unused re-export branches could offset the cost of bundling it.
+
+Do not scan every installed package or attempt to prove an internal Rspack optimization hit by reconstructing the whole module graph. Start from large packages observed in the build output, add one candidate at a time, and compare it with the fully externalized baseline. Keep the package bundled only when the same tests pass and the measured RSS or wall-time tradeoff improves; explicit side-effect metadata makes a package eligible, not automatically beneficial.
 
 ### Keep the DOM default and externalize heavy exceptions
 

--- a/skills/migrate-to-rstest/references/dom-dependency-bundling.md
+++ b/skills/migrate-to-rstest/references/dom-dependency-bundling.md
@@ -1,0 +1,83 @@
+# DOM Dependency Bundling and Peak RSS
+
+Use this reference when a migrated scope runs in `jsdom`, `happy-dom`, or another browser-like test environment and Rstest has materially higher peak RSS or build cost than Jest/Vitest.
+
+## Source of truth
+
+- Rstest output configuration: https://rstest.rs/config/build/output
+- Rstest profiling guide: https://rstest.rs/guide/advanced/profiling
+
+## Understand the default
+
+Rstest builds tests with Rsbuild/Rspack before executing them. In browser-like test environments, it bundles all third-party dependencies from `node_modules` by default; the `node` environment externalizes them by default. A migration can therefore increase build-time memory even when test-runtime behavior is unchanged.
+
+Do not confuse a browser-like environment with Rstest browser mode. `output.bundleDependencies: false` can change bundling for `jsdom` or `happy-dom` in non-browser mode. When `browser.enabled` is active, all dependencies remain bundled and that setting is unsupported.
+
+`output.bundleDependencies` was added in Rstest v0.9.5. Apply the dependency/version gate before using it.
+
+## Confirm the bottleneck
+
+Compare equivalent cold runs before editing the config: use the same Node version, test selection, coverage mode, worker count, and cache state. Record peak RSS and wall time for Rstest and the previous runner.
+
+If possible, use `DEBUG=rstest` and inspect whether the build stage or temporary output under `dist/.rstest-temp` is disproportionately large. If the regression is only in test execution, investigate concurrency, environment setup, and leaks instead of changing the bundle strategy.
+
+## Choose a bundling strategy
+
+### Externalize all dependencies
+
+Start here when most dependencies can run directly in Node and the DOM environment does not need them transformed by the bundler:
+
+```ts
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  testEnvironment: 'jsdom',
+  output: {
+    bundleDependencies: false,
+  },
+});
+```
+
+### Externalize by default and bundle exceptions
+
+Use an allowlist when only a few ESM or source-distributed packages still need Rstest/Rspack transformation:
+
+```ts
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  testEnvironment: 'jsdom',
+  output: {
+    bundleDependencies: ['esm-only-package', 'source-package/*'],
+  },
+});
+```
+
+An array sets an externalized baseline and bundles only matching package requests. It does not re-bundle transitive dependencies that are reachable only through an already externalized parent.
+
+### Keep the DOM default and externalize heavy exceptions
+
+Use `output.externals` when most dependencies should stay bundled but a few large packages dominate build memory:
+
+```ts
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  testEnvironment: 'jsdom',
+  output: {
+    externals: ['react', 'lodash'],
+  },
+});
+```
+
+`output.bundleDependencies` sets the baseline; `output.externals` adds per-package exceptions and takes priority when both match.
+
+## Validate each change
+
+After each adjustment:
+
+1. Run the same migrated test scope and confirm behavior, mocks, module resolution, and coverage remain correct.
+2. Re-measure peak RSS and wall time under the same conditions.
+3. Keep the narrowest configuration that produces a meaningful improvement.
+
+Externalized packages load at runtime instead of being transformed in the bundle. If externalization exposes ESM/CommonJS interop, syntax, alias, or package-condition failures, bundle the affected package or subpath again rather than rewriting tests to mask the issue.

--- a/skills/migrate-to-rstest/references/mocked-module-build-graph.md
+++ b/skills/migrate-to-rstest/references/mocked-module-build-graph.md
@@ -1,0 +1,48 @@
+# Mocked Modules and Build Graph Memory
+
+Use this reference when Rstest has high build time or peak main-process RSS even though the expensive module is replaced with `rs.mock()` in the test.
+
+## Source of truth
+
+- Rstest module mocking: https://rstest.rs/api/runtime-api/rstest/mock-modules
+- Rstest output configuration: https://rstest.rs/config/build/output
+
+## Why the module is still compiled
+
+Treat `rs.mock()` as runtime module replacement, not build-graph pruning. Rspack discovers the static import while building the test and can still compile the real module and its reachable source graph before Rstest installs or uses the runtime mock.
+
+This commonly appears when a small component test fully mocks a renderer, editor, document processor, or other module whose real implementation imports a large package or source tree. The test execution can be cheap while the build remains expensive.
+
+## Run the narrow experiment
+
+1. Confirm that the heavy module is fully mocked and its real exports, initialization side effects, and coverage are not part of the test's intent.
+2. Add only the exact mocked import request to `output.externals`. Do not externalize the large transitive package first: cutting the graph at the already-mocked boundary is narrower and preserves more normal bundling behavior.
+3. Run the affected test file with the same Node version, coverage, workers, and cache state. Compare passed tests, peak RSS, and build time with the baseline.
+4. Keep the rule only when behavior remains identical and the resource reduction is material. A large RSS/build-time drop with the same tests passing is strong evidence that compiling the unused real module graph was the primary cost.
+
+For a package or stable alias import, the experiment can be as small as:
+
+```ts
+import { defineConfig } from '@rstest/core';
+
+const fullyMockedModule = '@app/MarkdownRender';
+
+export default defineConfig({
+  output: {
+    externals: [fullyMockedModule],
+  },
+});
+```
+
+Match the request string seen by Rspack. If the import uses a relative path, an alias, or multiple package paths, inspect the effective requests and use the narrowest supported string, regular expression, object, or function rule rather than a broad name fragment.
+
+## Scope and safety checks
+
+`output.externals` applies to the whole Rstest config or project, not only the test file that motivated it. Before keeping the rule:
+
+- Run every test in that config/project which imports the externalized module, including tests that may not mock it.
+- Do not use this optimization for partial mocks, `importActual`, `{ spy: true }`, or tests that exercise the real module or its side effects.
+- Confirm the mock matches the same module request and is registered before the tested code loads it. A missed mock may make the runtime resolve an externalized local TypeScript/source module without Rspack transformation.
+- Recheck module aliases, ESM/CommonJS interop, package export conditions, snapshots, and coverage.
+
+If only one subset fully mocks the module, isolate that subset as a separate Rstest project with its own `output.externals` rule instead of weakening bundling for unrelated tests.


### PR DESCRIPTION
## Summary

This PR updates the `migrate-to-rstest` skill to diagnose config-loading warnings and peak RSS/build-time regressions introduced by Rstest's Rsbuild/Rspack execution model.

- Resolves `[MODULE_TYPELESS_PACKAGE_JSON]` with an explicit config module format, preferring `rstest.config.mts` for CommonJS or mixed packages instead of changing package-wide module semantics.
- Documents dependency bundling defaults for `jsdom` and `happy-dom`, with measured tuning guidance for `output.bundleDependencies`, `output.externals`, and eligible lazy-barrel candidates.
- Explains that `rs.mock()` does not prune the mocked module from Rspack's build graph, and adds a narrowly scoped externalization experiment with safety checks.
- Clarifies that shared devDependencies require repository-wide usage checks before cleanup in a monorepo migration.

## Related Links

- https://rstest.rs/guide/basic/configure-rstest
- https://rsbuild.rs/guide/configuration/rsbuild
- https://rstest.rs/config/build/output
- https://rstest.rs/guide/advanced/profiling
- https://rspack.rs/guide/optimization/lazy-barrel
- https://rstest.rs/api/runtime-api/rstest/mock-modules