### PR TITLE
feat(plugin): add Claude Code support

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-marketplace.json",
+  "name": "rstack",
+  "description": "Agent Skills for debugging, tracing, upgrading, and analyzing Rstack projects.",
+  "owner": {
+    "name": "RstackJS"
+  },
+  "plugins": [
+    {
+      "name": "rstack",
+      "description": "Agent Skills for debugging, tracing, upgrading, and analyzing Rstack projects.",
+      "version": "0.1.0",
+      "source": "./",
+      "author": {
+        "name": "RstackJS"
+      }
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "rstack",
+  "version": "0.1.0",
+  "description": "Agent Skills for debugging, tracing, upgrading, and analyzing Rstack projects.",
+  "author": {
+    "name": "RstackJS"
+  },
+  "homepage": "https://github.com/rstackjs/agent-skills",
+  "repository": "https://github.com/rstackjs/agent-skills",
+  "license": "MIT",
+  "keywords": [
+    "rspack",
+    "rsbuild",
+    "rslib",
+    "rstest",
+    "rspress",
+    "rsdoctor",
+    "rslint",
+    "storybook",
+    "skills"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ codex plugin marketplace add rstackjs/agent-skills
 codex plugin add rstack@rstack
 ```
 
+Install all user-facing skills as a Claude Code plugin:
+
+```bash
+claude plugin marketplace add rstackjs/agent-skills
+claude plugin install rstack@rstack
+```
+
 Install any skill with:
 
 ```bash


### PR DESCRIPTION
## Summary

This PR exposes the repository's public Rstack skills as an installable Claude Code plugin. The Claude marketplace points to the repository root, matching the Superpowers layout, so the existing `skills/` directory remains the single source of truth without copied skill trees.

```tree
agent-skills/
├── .claude-plugin/
│   ├── marketplace.json
│   └── plugin.json
└── skills/
```

Users can install it as `rstack@rstack`:

```bash
claude plugin marketplace add rstackjs/agent-skills
claude plugin install rstack@rstack
```

## Related Links

- https://github.com/rstackjs/agent-skills/pull/93
- https://github.com/obra/superpowers/tree/main/.claude-plugin
- https://code.claude.com/docs/en/plugin-marketplaces