### PR TITLE
feat(plugin): add portable Agent Plugins support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,19 +28,42 @@ A collection of Agent Skills for [Rstack](https://rspack.rs/guide/start/ecosyste
 
 ## Usage
 
-Install all user-facing skills as a Codex plugin:
+### Codex
 
 ```bash
 codex plugin marketplace add rstackjs/agent-skills
 codex plugin add rstack@rstack
 ```
 
-Install all user-facing skills as a Claude Code plugin:
+### VS Code
+
+Run **Chat: Install Plugin From Source**, then enter:
+
+```text
+https://github.com/rstackjs/agent-skills
+```
+
+### Cursor
+
+```bash
+git clone https://github.com/rstackjs/agent-skills.git ~/.cursor/plugins/local/rstack
+```
+
+### GitHub Copilot
+
+```bash
+copilot plugin marketplace add rstackjs/agent-skills
+copilot plugin install rstack@rstack
+```
+
+### Claude Code
 
 ```bash
 claude plugin marketplace add rstackjs/agent-skills
 claude plugin install rstack@rstack
 ```
+
+### Individual skills
 
 Install any skill with:
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "rstack",
+  "version": "0.1.0",
+  "description": "Agent Skills for debugging, tracing, upgrading, and analyzing Rstack projects.",
+  "author": {
+    "name": "RstackJS",
+    "url": "https://github.com/rstackjs"
+  },
+  "homepage": "https://github.com/rstackjs/agent-skills",
+  "repository": "https://github.com/rstackjs/agent-skills",
+  "license": "MIT",
+  "keywords": [
+    "rspack",
+    "rsbuild",
+    "rslib",
+    "rstest",
+    "rspress",
+    "rsdoctor",
+    "rslint",
+    "storybook",
+    "skills"
+  ]
+}


### PR DESCRIPTION
## Summary

This PR exposes the repository's public `skills/` directory as an Agent Plugins 1.0 package through a root `plugin.json`, so compatible clients can install the Rstack skills from one repository without including internal `.agents/skills/`.

The existing Codex and Claude Code packages remain available, and the README now gives Codex, VS Code, Cursor, GitHub Copilot, and Claude Code one concise installation path each.

## Related Links

- https://agent-plugins.org/plugin-authors
- https://github.com/rstackjs/agent-skills/pull/93
- https://github.com/rstackjs/agent-skills/pull/100
