### PR TITLE
fix(plugin): narrow Rsbuild migration prompt

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -32,7 +32,7 @@
     "logo": "./assets/rspack-logo.png",
     "defaultPrompt": [
       "Debug and optimize this Rspack build.",
-      "Migrate this webpack or Vite project to Rsbuild.",
+      "Migrate this webpack project to Rsbuild.",
       "Create or improve the Rspress documentation for this project."
     ],
     "websiteURL": "https://github.com/rstackjs/agent-skills"


### PR DESCRIPTION
## Summary

This PR narrows the Codex plugin's Rsbuild migration starter prompt to webpack projects, avoiding a Vite migration suggestion in the default prompt list.