### PR TITLE
fix(skills): resolve bundled resources portably

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,10 +61,8 @@ Use this for installable Skills intended for Rspack ecosystem users.
 
 - Place the Skill in `skills/{skill-name}/`.
 - Reference bundled scripts, references, and assets with paths relative to the
-  Skill root. Do not make a client-specific environment variable or install
-  layout the only way to resolve a public Skill resource. Client-specific paths
-  may be documented as optional examples when a portable resource path remains
-  the source of truth.
+  Skill root. Do not rely on client-specific environment variables or
+  installation layouts.
 
 Start `SKILL.md` with YAML frontmatter:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,11 @@ Write the Skill content with the use cases, workflow, examples, and links to det
 Use this for installable Skills intended for Rspack ecosystem users.
 
 - Place the Skill in `skills/{skill-name}/`.
+- Reference bundled scripts, references, and assets with paths relative to the
+  Skill root. Do not make a client-specific environment variable or install
+  layout the only way to resolve a public Skill resource. Client-specific paths
+  may be documented as optional examples when a portable resource path remains
+  the source of truth.
 
 Start `SKILL.md` with YAML frontmatter:
 

--- a/skills/rsdoctor-analysis/SKILL.md
+++ b/skills/rsdoctor-analysis/SKILL.md
@@ -112,6 +112,6 @@ Recovery rules:
 - Command not found: run Analysis Gate, then retry with `rsdoctor-agent`.
 - `query` reports unknown tool: run `list` and use a catalog tool name, or switch to direct `<group> <subcommand>` mode.
 - JSON read error: verify file path, JSON validity, and permissions.
-- In Codex, do not run `install`, `build`, global CLI installation, version checks, or `rsdoctor-agent...` inside sandbox. Run Rsdoctor CLI setup and data-fetch commands outside sandbox so they can access project files and dependencies normally.
+- Run installs, builds, version checks, and `rsdoctor-agent...` commands only in the host's authorized command environment when it has the required project, dependency, and network access. If the available environment lacks that access, stop and ask the user instead of attempting to bypass the sandbox or permission boundary.
 
 References: commands/options [references/command-map.md](references/command-map.md); install/config/data location [references/install-rsdoctor.md](references/install-rsdoctor.md), [references/install-rsdoctor-rspack.md](references/install-rsdoctor-rspack.md), [references/install-rsdoctor-webpack.md](references/install-rsdoctor-webpack.md), [references/install-rsdoctor-common.md](references/install-rsdoctor-common.md); raw data fields [references/rsdoctor-data-types.md](references/rsdoctor-data-types.md); common patterns [references/common-analysis-patterns.md](references/common-analysis-patterns.md).

--- a/skills/rspack-debugging/SKILL.md
+++ b/skills/rspack-debugging/SKILL.md
@@ -24,16 +24,12 @@ Before starting, please ensure your environment meets the requirements.
     **Automatic Replacement Script**:
 
     Resolve the bundled [`scripts/setup_debug_deps.cjs`](scripts/setup_debug_deps.cjs)
-    resource relative to this `SKILL.md`, not the user's project directory, then run:
+    relative to the Skill root while keeping the working directory in the user's
+    project, then run:
 
     ```bash
-    node "<skill-directory>/scripts/setup_debug_deps.cjs"
+    node "<skill-root>/scripts/setup_debug_deps.cjs"
     ```
-
-    If the client exposes Skill resources as content instead of filesystem paths,
-    materialize that exact bundled resource to a temporary file before running it.
-    In a Claude Code plugin installation, `<skill-directory>` is
-    `${CLAUDE_PLUGIN_ROOT}/skills/rspack-debugging`.
 
     Running the above script will automatically add `pnpm.overrides` configuration to `package.json`, pointing Rspack packages to their corresponding Debug versions. Afterwards, please be sure to run `pnpm install` to update dependencies.
 
@@ -89,9 +85,8 @@ When you successfully obtain a backtrace or a tracing log, you **MUST** save it 
 After debugging is complete, restore your `package.json` to use production packages:
 
 ```bash
-node "<skill-directory>/scripts/setup_debug_deps.cjs" --restore
+node "<skill-root>/scripts/setup_debug_deps.cjs" --restore
 pnpm install
 ```
 
-Resolve `<skill-directory>` using the same Skill-resource mechanism described in
-Preparation.
+Use the same resolved `<skill-root>` as in Preparation.

--- a/skills/rspack-debugging/SKILL.md
+++ b/skills/rspack-debugging/SKILL.md
@@ -23,9 +23,17 @@ Before starting, please ensure your environment meets the requirements.
 
     **Automatic Replacement Script**:
 
+    Resolve the bundled [`scripts/setup_debug_deps.cjs`](scripts/setup_debug_deps.cjs)
+    resource relative to this `SKILL.md`, not the user's project directory, then run:
+
     ```bash
-    node ${CLAUDE_PLUGIN_ROOT}/skills/debugging/scripts/setup_debug_deps.cjs
+    node "<skill-directory>/scripts/setup_debug_deps.cjs"
     ```
+
+    If the client exposes Skill resources as content instead of filesystem paths,
+    materialize that exact bundled resource to a temporary file before running it.
+    In a Claude Code plugin installation, `<skill-directory>` is
+    `${CLAUDE_PLUGIN_ROOT}/skills/rspack-debugging`.
 
     Running the above script will automatically add `pnpm.overrides` configuration to `package.json`, pointing Rspack packages to their corresponding Debug versions. Afterwards, please be sure to run `pnpm install` to update dependencies.
 
@@ -81,6 +89,9 @@ When you successfully obtain a backtrace or a tracing log, you **MUST** save it 
 After debugging is complete, restore your `package.json` to use production packages:
 
 ```bash
-node ${CLAUDE_PLUGIN_ROOT}/skills/debugging/scripts/setup_debug_deps.cjs --restore
+node "<skill-directory>/scripts/setup_debug_deps.cjs" --restore
 pnpm install
 ```
+
+Resolve `<skill-directory>` using the same Skill-resource mechanism described in
+Preparation.

--- a/skills/rspack-tracing/SKILL.md
+++ b/skills/rspack-tracing/SKILL.md
@@ -45,20 +45,15 @@ The last events will show the span names and targets where the build stopped, he
 
 ### 3. Full Performance Analysis
 
-For detailed performance profiling (not just crash diagnosis), ask the user to run the bundled [`scripts/analyze_trace.js`](scripts/analyze_trace.js) resource on the generated trace file. Resolve the resource relative to this `SKILL.md`, not the user's project directory.
+For detailed performance profiling (not just crash diagnosis), ask the user whether to run the bundled [`scripts/analyze_trace.js`](scripts/analyze_trace.js) on the generated trace file. If they agree, resolve it relative to the Skill root while keeping the working directory in the user's project, then run:
 
 ```bash
 # Navigate to the generated profile directory
 cd .rspack-profile-*/
 
 # Run the analysis script
-node "<skill-directory>/scripts/analyze_trace.js" trace.json
+node "<skill-root>/scripts/analyze_trace.js" trace.json
 ```
-
-If the client exposes Skill resources as content instead of filesystem paths,
-materialize that exact bundled resource to a temporary file before running it.
-In a Claude Code plugin installation, `<skill-directory>` is
-`${CLAUDE_PLUGIN_ROOT}/skills/rspack-tracing`.
 
 ### 4. Interpret Results
 

--- a/skills/rspack-tracing/SKILL.md
+++ b/skills/rspack-tracing/SKILL.md
@@ -45,15 +45,20 @@ The last events will show the span names and targets where the build stopped, he
 
 ### 3. Full Performance Analysis
 
-For detailed performance profiling (not just crash diagnosis), ask the user to run the bundled analysis script on the generated trace file.
+For detailed performance profiling (not just crash diagnosis), ask the user to run the bundled [`scripts/analyze_trace.js`](scripts/analyze_trace.js) resource on the generated trace file. Resolve the resource relative to this `SKILL.md`, not the user's project directory.
 
 ```bash
 # Navigate to the generated profile directory
 cd .rspack-profile-*/
 
 # Run the analysis script
-node ${CLAUDE_PLUGIN_ROOT}/skills/tracing/scripts/analyze_trace.js trace.json
+node "<skill-directory>/scripts/analyze_trace.js" trace.json
 ```
+
+If the client exposes Skill resources as content instead of filesystem paths,
+materialize that exact bundled resource to a temporary file before running it.
+In a Claude Code plugin installation, `<skill-directory>` is
+`${CLAUDE_PLUGIN_ROOT}/skills/rspack-tracing`.
 
 ### 4. Interpret Results
 

--- a/skills/rspack-tracing/references/tracing-guide.md
+++ b/skills/rspack-tracing/references/tracing-guide.md
@@ -31,8 +31,10 @@ After running the command, Rspack will generate the file specified in `RSPACK_TR
 ## Using the Skill's Analysis Tool
 
 This skill includes a script to summarize the trace file.
+Resolve `scripts/analyze_trace.js` relative to the Skill root while keeping the
+working directory in the user's project.
 
 ```bash
 # Run the included script
-node scripts/analyze_trace.js <path-to-trace-file>
+node "<skill-root>/scripts/analyze_trace.js" <path-to-trace-file>
 ```


### PR DESCRIPTION
## Summary

- make bundled script resources resolve relative to each Skill instead of requiring a client-specific plugin root
- preserve the Claude Code plugin mapping while fixing the existing `debugging` and `tracing` directory paths
- generalize sandbox guidance for clients with different execution boundaries
- document the portability rule for future public Skills

## Why

The public `skills/` tree is exposed through Claude Code, Codex, and portable Agent Plugins, but two script commands currently depend on `${CLAUDE_PLUGIN_ROOT}` and point to directories that do not exist. Skill-relative resource paths follow the Agent Skills specification and also work for clients that expose resources as content rather than direct filesystem paths.

## Validation

- `pnpm lint`
- `pnpm build`
- `uvx --from skills-ref agentskills validate skills/rspack-debugging`
- `uvx --from skills-ref agentskills validate skills/rspack-tracing`
- `uvx --from skills-ref agentskills validate skills/rsdoctor-analysis`