### PR TITLE
docs: recommend Agent Plugin installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ A collection of Agent Skills for [Rstack](https://rspack.rs/guide/start/ecosyste
 
 ## Usage
 
+We recommend installing this repository as an [Agent Plugin](https://agent-plugins.org/). The Rstack Agent Plugin follows the open, vendor-neutral Agent Plugins 1.0 standard and works with compatible agent clients, including VS Code, GitHub Copilot, Codex, Cursor, and more.
+
 ### Codex
 
 ```bash


### PR DESCRIPTION
This PR clarifies the recommended installation path for the Rstack Agent Skills collection. It keeps the repository positioned as a skills collection while documenting the Agent Plugins 1.0-based installation option and its compatible clients in the Usage section.

## Related Links

- https://agent-plugins.org/