### PR TITLE
feat: add rstack-docs-writer skill

### DIFF
--- a/.agents/skills/rstack-docs-writer/SKILL.md
+++ b/.agents/skills/rstack-docs-writer/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: rstack-docs-writer
+description: Write or revise Markdown and MDX documentation, including READMEs, guides, and Rspress-based docs.
+metadata:
+  internal: true
+---
+
+# Rstack Docs Writer
+
+Follow the project's existing documentation conventions.
+
+## Writing
+
+- Explain user-facing behavior concisely, adding details and examples only when they help users configure or use the feature.
+- Keep common abbreviations such as `dev server`.
+- Keep documentation in sync across locales when changing content. Use English as the default language unless the project specifies another.
+- Use sentence-case headings.
+
+## Heading anchors
+
+- Prefer Rspress's default anchors for headings in the default locale; preserve intentional existing custom IDs.
+- Determine generated anchors from heading `id` attributes: run the project's docs dev command and inspect the rendered browser DOM, or run its docs build command and inspect the generated HTML.
+- Match headings in other locales to the default locale's anchors, using the project's locale mapping to pair pages. Add custom IDs where defaults differ; remove redundant IDs only if anchors stay unchanged.
+- Escape custom IDs in MDX: `## Localized heading \{#default-locale-anchor}`.
+- When anchors change, update corresponding IDs across locales and affected Markdown links and JSX `href` attributes. Check target pages before replacing hashes.
+- Check changed links against their target headings.

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,5 @@ skills-test/**/*
 !.agents/skills/rstack-eco-ci-debug/**
 !.agents/skills/release-blog-writer/
 !.agents/skills/release-blog-writer/**
+!.agents/skills/rstack-docs-writer/
+!.agents/skills/rstack-docs-writer/**

--- a/README.md
+++ b/README.md
@@ -295,6 +295,14 @@ INSTALL_INTERNAL_SKILLS=1 npx skills add rstackjs/agent-skills --skill release-b
 
 Write or revise release blog posts for product releases, with guidance for structure, tone, headings, examples, and links.
 
+### rstack-docs-writer
+
+```bash
+INSTALL_INTERNAL_SKILLS=1 npx skills add rstackjs/agent-skills --skill rstack-docs-writer
+```
+
+Write or revise Markdown and MDX documentation, including READMEs, guides, and Rspress-based docs.
+
 ### mdx-to-markdown
 
 ```bash

--- a/skills.json
+++ b/skills.json
@@ -10,7 +10,8 @@
     "create-draft-release-notes": "local:*",
     "rstack-repo-maintain": "local:*",
     "rstack-eco-ci-debug": "local:*",
-    "release-blog-writer": "local:*"
+    "release-blog-writer": "local:*",
+    "rstack-docs-writer": "local:*"
   },
   "selfSkill": true
 }


### PR DESCRIPTION
Add an internal skill for writing and revising Markdown and MDX documentation, with guidance on concise writing, locale synchronization, and Rspress heading anchors. Register it as a local skill and document its internal installation.